### PR TITLE
RDSQDRN-23: Update methods to support Java 8 for Detect

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,10 @@ ext {
     javaTargetCompatibility = JavaVersion.VERSION_1_8
 }
 
+tasks.compileJava {
+    options.release = 8
+}
+
 group 'com.synopsys.integration'
 version = '1.0.2-SNAPSHOT'
 

--- a/src/main/java/com/synopsys/blackduck/upload/client/uploaders/ArtifactsUploader.java
+++ b/src/main/java/com/synopsys/blackduck/upload/client/uploaders/ArtifactsUploader.java
@@ -1,6 +1,7 @@
 package com.synopsys.blackduck.upload.client.uploaders;
 
 import java.nio.file.Path;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
@@ -58,7 +59,9 @@ public class ArtifactsUploader extends AbstractUploader<UploadStatus> {
      */
     @Override
     protected Map<String, String> getMultipartUploadStartRequestHeaders() {
-        return Map.of(HttpHeaders.CONTENT_TYPE, ContentTypes.APPLICATION_MULTIPART_UPLOAD_START_V1);
+        Map<String, String> headers = new HashMap<>();
+        headers.put(HttpHeaders.CONTENT_TYPE, ContentTypes.APPLICATION_MULTIPART_UPLOAD_START_V1);
+        return headers;
     }
 
     /**

--- a/src/main/java/com/synopsys/blackduck/upload/client/uploaders/BinaryUploader.java
+++ b/src/main/java/com/synopsys/blackduck/upload/client/uploaders/BinaryUploader.java
@@ -81,7 +81,9 @@ public class BinaryUploader extends AbstractUploader<BinaryUploadStatus> {
      */
     @Override
     protected Map<String, String> getMultipartUploadStartRequestHeaders() {
-        return Map.of(HttpHeaders.CONTENT_TYPE, ContentTypes.APPLICATION_BINARY_MULTIPART_UPLOAD_START_V1);
+        Map<String, String> headers = new HashMap<>();
+        headers.put(HttpHeaders.CONTENT_TYPE, ContentTypes.APPLICATION_BINARY_MULTIPART_UPLOAD_START_V1);
+        return headers;
     }
 
     /**

--- a/src/main/java/com/synopsys/blackduck/upload/client/uploaders/ContainerUploader.java
+++ b/src/main/java/com/synopsys/blackduck/upload/client/uploaders/ContainerUploader.java
@@ -1,6 +1,7 @@
 package com.synopsys.blackduck.upload.client.uploaders;
 
 import java.nio.file.Path;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
@@ -58,7 +59,9 @@ public class ContainerUploader extends AbstractUploader<UploadStatus> {
      */
     @Override
     protected Map<String, String> getMultipartUploadStartRequestHeaders() {
-        return Map.of(HttpHeaders.CONTENT_TYPE, ContentTypes.APPLICATION_MULTIPART_UPLOAD_START_V1);
+        Map<String, String> headers = new HashMap<>();
+        headers.put(HttpHeaders.CONTENT_TYPE, ContentTypes.APPLICATION_MULTIPART_UPLOAD_START_V1);
+        return headers;
     }
 
     /**

--- a/src/main/java/com/synopsys/blackduck/upload/client/uploaders/ReversingLabUploader.java
+++ b/src/main/java/com/synopsys/blackduck/upload/client/uploaders/ReversingLabUploader.java
@@ -1,6 +1,7 @@
 package com.synopsys.blackduck.upload.client.uploaders;
 
 import java.nio.file.Path;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
@@ -58,7 +59,9 @@ public class ReversingLabUploader extends AbstractUploader<UploadStatus> {
      */
     @Override
     protected Map<String, String> getMultipartUploadStartRequestHeaders() {
-        return Map.of(HttpHeaders.CONTENT_TYPE, ContentTypes.APPLICATION_MULTIPART_UPLOAD_START_V1);
+        Map<String, String> headers = new HashMap<>();
+        headers.put(HttpHeaders.CONTENT_TYPE, ContentTypes.APPLICATION_MULTIPART_UPLOAD_START_V1);
+        return headers;
     }
 
     /**

--- a/src/main/java/com/synopsys/blackduck/upload/client/uploaders/ToolsUploader.java
+++ b/src/main/java/com/synopsys/blackduck/upload/client/uploaders/ToolsUploader.java
@@ -1,6 +1,7 @@
 package com.synopsys.blackduck.upload.client.uploaders;
 
 import java.nio.file.Path;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
@@ -58,7 +59,9 @@ public class ToolsUploader extends AbstractUploader<UploadStatus> {
      */
     @Override
     protected Map<String, String> getMultipartUploadStartRequestHeaders() {
-        return Map.of(HttpHeaders.CONTENT_TYPE, ContentTypes.APPLICATION_MULTIPART_UPLOAD_START_V1);
+        Map<String, String> headers = new HashMap<>();
+        headers.put(HttpHeaders.CONTENT_TYPE, ContentTypes.APPLICATION_MULTIPART_UPLOAD_START_V1);
+        return headers;
     }
 
     /**

--- a/src/main/java/com/synopsys/blackduck/upload/validation/UploaderValidationException.java
+++ b/src/main/java/com/synopsys/blackduck/upload/validation/UploaderValidationException.java
@@ -1,6 +1,7 @@
 package com.synopsys.blackduck.upload.validation;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -50,14 +51,14 @@ public class UploaderValidationException extends IntegrationException implements
      */
     public UploaderValidationException(Throwable cause) {
         super(cause);
-        this.uploadErrors = List.of();
+        this.uploadErrors = new ArrayList<>();
     }
 
     /**
      * Constructs an empty exception.
      */
     public UploaderValidationException() {
-        this.uploadErrors = List.of();
+        this.uploadErrors = new ArrayList<>();
     }
 
     /**


### PR DESCRIPTION
Detect QA discovered runtime exceptions that would occur in the library when testing with Java 8. These included collections features introduced in Java 9. Additionally, this adds an additional task in the build.gradle to set the release level to Java 8 to avoid some override issues in classes such as ByteBuffer which also produced runtime errors in Detect.