### PR TITLE
RDSQDRN-25: Update builder methods for UploadConfig and assign new defaults

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ tasks.compileJava {
 }
 
 group 'com.synopsys.integration'
-version = '1.0.3-SNAPSHOT'
+version = '1.1.0-SNAPSHOT'
 
 apply plugin: 'com.synopsys.integration.library'
 

--- a/src/main/java/com/synopsys/blackduck/upload/client/EnvironmentProperties.java
+++ b/src/main/java/com/synopsys/blackduck/upload/client/EnvironmentProperties.java
@@ -10,8 +10,8 @@ import java.util.stream.Collectors;
  * Enum to handle properties coming from environment.
  */
 public enum EnvironmentProperties {
-    BLACKDUCK_UPLOAD_CHUNK_SIZE("blackduck.upload.chunk.size", true),
-    BLACKDUCK_TIMEOUT_SECONDS("blackduck.timeout.seconds", true),
+    BLACKDUCK_UPLOAD_CHUNK_SIZE("blackduck.upload.chunk.size", false),
+    BLACKDUCK_TIMEOUT_SECONDS("blackduck.timeout.seconds", false),
     BLACKDUCK_TRUST_CERT("blackduck.trust.cert", true),
     BLACKDUCK_URL("blackduck.url", true),
     BLACKDUCK_API_TOKEN("blackduck.api.token", true),

--- a/src/main/java/com/synopsys/blackduck/upload/client/UploaderConfig.java
+++ b/src/main/java/com/synopsys/blackduck/upload/client/UploaderConfig.java
@@ -8,6 +8,7 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.collections.CollectionUtils;
 
+import com.synopsys.blackduck.upload.rest.BlackDuckHttpClient;
 import com.synopsys.blackduck.upload.validation.ErrorCode;
 import com.synopsys.blackduck.upload.validation.UploadError;
 import com.synopsys.blackduck.upload.validation.UploadValidator;
@@ -286,7 +287,7 @@ public class UploaderConfig {
          */
         public int getTimeoutInSeconds() {
             Optional<String> timeoutInSeconds = Optional.ofNullable(getPropertyValue(EnvironmentProperties.BLACKDUCK_TIMEOUT_SECONDS.getPropertyKey()));
-            return timeoutInSeconds.map(Integer::parseInt).orElse(300);
+            return timeoutInSeconds.map(Integer::parseInt).orElse(BlackDuckHttpClient.DEFAULT_BLACKDUCK_TIMEOUT_SECONDS);
         }
 
         /**

--- a/src/main/java/com/synopsys/blackduck/upload/client/UploaderConfig.java
+++ b/src/main/java/com/synopsys/blackduck/upload/client/UploaderConfig.java
@@ -292,7 +292,7 @@ public class UploaderConfig {
         /**
          * Retrieve current builder value for trusting the Black Duck server certificate.
          *
-         * @return configured or default timeout in seconds.
+         * @return configured value to trust server certificate.
          */
         public boolean isAlwaysTrustServerCertificate() {
             return Boolean.parseBoolean(getPropertyValue(EnvironmentProperties.BLACKDUCK_TRUST_CERT.getPropertyKey()));

--- a/src/main/java/com/synopsys/blackduck/upload/client/UploaderConfig.java
+++ b/src/main/java/com/synopsys/blackduck/upload/client/UploaderConfig.java
@@ -241,13 +241,14 @@ public class UploaderConfig {
         public UploaderConfig build() throws IntegrationException {
             validate();
 
+            // Black Duck URL and API token are validated prior to construction, therefore those values should never be null.
             return new UploaderConfig(
                 proxyInfo,
                 getUploadChunkSize(),
                 getTimeoutInSeconds(),
                 isAlwaysTrustServerCertificate(),
-                getBlackDuckUrl(),
-                getApiToken(),
+                getBlackDuckUrl().orElse(null),
+                getApiToken().orElse(null),
                 getMultipartUploadThreshold(),
                 getMultipartUploadPartRetryAttempts(),
                 getMultipartUploadPartRetryInitialInterval(),
@@ -267,47 +268,99 @@ public class UploaderConfig {
             }
         }
 
-        private int getUploadChunkSize() {
-            return Integer.parseInt(getPropertyValue(EnvironmentProperties.BLACKDUCK_UPLOAD_CHUNK_SIZE.getPropertyKey()));
+
+        /**
+         * Retrieve current builder value for the size of uploading chunks to Black Duck.
+         *
+         * @return configured or default upload chunk size.
+         */
+        public int getUploadChunkSize() {
+            Optional<String> uploadChunkSizeProperty = Optional.ofNullable(getPropertyValue(EnvironmentProperties.BLACKDUCK_UPLOAD_CHUNK_SIZE.getPropertyKey()));
+            return uploadChunkSizeProperty.map(Integer::parseInt).orElse(UploadValidator.DEFAULT_UPLOAD_CHUNK_SIZE);
         }
 
-        private int getTimeoutInSeconds() {
-            return Integer.parseInt(getPropertyValue(EnvironmentProperties.BLACKDUCK_TIMEOUT_SECONDS.getPropertyKey()));
+        /**
+         * Retrieve current builder value for the timeout when communicating with Black Duck.
+         *
+         * @return configured or default timeout in seconds.
+         */
+        public int getTimeoutInSeconds() {
+            Optional<String> timeoutInSeconds = Optional.ofNullable(getPropertyValue(EnvironmentProperties.BLACKDUCK_TIMEOUT_SECONDS.getPropertyKey()));
+            return timeoutInSeconds.map(Integer::parseInt).orElse(300);
         }
 
-        private boolean isAlwaysTrustServerCertificate() {
+        /**
+         * Retrieve current builder value for trusting the Black Duck server certificate.
+         *
+         * @return configured or default timeout in seconds.
+         */
+        public boolean isAlwaysTrustServerCertificate() {
             return Boolean.parseBoolean(getPropertyValue(EnvironmentProperties.BLACKDUCK_TRUST_CERT.getPropertyKey()));
         }
 
-        private HttpUrl getBlackDuckUrl() throws IntegrationException {
-            return new HttpUrl(getPropertyValue(EnvironmentProperties.BLACKDUCK_URL.getPropertyKey()));
+        /**
+         * Retrieve current builder value for the Black Duck {@link HttpUrl}.
+         *
+         * @return {@link Optional} configured Black Duck {@link HttpUrl}.
+         */
+        public Optional<HttpUrl> getBlackDuckUrl() throws IntegrationException {
+            Optional<String> blackduckUrlProperty = Optional.ofNullable(getPropertyValue(EnvironmentProperties.BLACKDUCK_URL.getPropertyKey()));
+            if (blackduckUrlProperty.isPresent()) {
+                return Optional.of(new HttpUrl(blackduckUrlProperty.get()));
+            }
+            return Optional.empty();
         }
 
-        private String getApiToken() {
-            return getPropertyValue(EnvironmentProperties.BLACKDUCK_API_TOKEN.getPropertyKey());
+        /**
+         * Retrieve current builder value for the Black Duck API token.
+         *
+         * @return {@link Optional} configured api token.
+         */
+        public Optional<String> getApiToken() {
+            return Optional.ofNullable(getPropertyValue(EnvironmentProperties.BLACKDUCK_API_TOKEN.getPropertyKey()));
         }
 
-        private Long getMultipartUploadThreshold() {
+        /**
+         * Retrieve current builder value for the multipart upload threshold.
+         *
+         * @return configured or default multipart upload threshold.
+         */
+        public Long getMultipartUploadThreshold() {
             Optional<String> multipartUploadThresholdProperty = Optional.ofNullable(getPropertyValue(EnvironmentProperties.BLACKDUCK_MULTIPART_UPLOAD_THRESHOLD.getPropertyKey()));
             return multipartUploadThresholdProperty.map(Long::parseLong)
                 .orElse(UploadValidator.DEFAULT_MULTIPART_UPLOAD_FILE_SIZE_THRESHOLD);
         }
 
-        private Integer getMultipartUploadPartRetryAttempts() {
+        /**
+         * Retrieve current builder value for the multipart retry attempts.
+         *
+         * @return configured or default multipart retry attempts.
+         */
+        public Integer getMultipartUploadPartRetryAttempts() {
             Optional<String> multipartUploadPartRetryAttemptsProperty =
                 Optional.ofNullable(getPropertyValue(EnvironmentProperties.BLACKDUCK_MULTIPART_UPLOAD_PART_RETRY_ATTEMPTS.getPropertyKey()));
             return multipartUploadPartRetryAttemptsProperty.map(Integer::parseInt)
                 .orElse(UploadValidator.DEFAULT_MULTIPART_UPLOAD_PART_RETRY_ATTEMPTS);
         }
 
-        private Long getMultipartUploadPartRetryInitialInterval() {
+        /**
+         * Retrieve current builder value for the multipart retry initial interval.
+         *
+         * @return configured or default multipart retry initial interval.
+         */
+        public Long getMultipartUploadPartRetryInitialInterval() {
             Optional<String> multipartUploadPartRetryInitialIntervalProperty =
                 Optional.ofNullable(getPropertyValue(EnvironmentProperties.BLACKDUCK_MULTIPART_UPLOAD_PART_RETRY_INITIAL_INTERVAL.getPropertyKey()));
             return multipartUploadPartRetryInitialIntervalProperty.map(Long::parseLong)
                 .orElse(UploadValidator.DEFAULT_MULTIPART_UPLOAD_PART_RETRY_INITIAL_INTERVAL);
         }
 
-        private Integer getMultipartUploadTimeoutInMinutes() {
+        /**
+         * Retrieve current builder value for the multipart upload timeout in minutes.
+         *
+         * @return configured or default multipart upload timeout in minutes.
+         */
+        public Integer getMultipartUploadTimeoutInMinutes() {
             Optional<String> multipartUploadTimeoutMinutesProperty =
                 Optional.ofNullable(getPropertyValue(EnvironmentProperties.BLACKDUCK_MULTIPART_UPLOAD_TIMEOUT_MINUTES.getPropertyKey()));
             return multipartUploadTimeoutMinutesProperty.map(Integer::parseInt)

--- a/src/main/java/com/synopsys/blackduck/upload/rest/BlackDuckHttpClient.java
+++ b/src/main/java/com/synopsys/blackduck/upload/rest/BlackDuckHttpClient.java
@@ -26,6 +26,8 @@ import com.synopsys.integration.rest.support.AuthenticationSupport;
  * The class to execute Black Duck REST API requests to a Black Duck server.
  */
 public class BlackDuckHttpClient extends AuthenticatingIntHttpClient {
+    public static int DEFAULT_BLACKDUCK_TIMEOUT_SECONDS = 300;
+
     private static final String AUTHORIZATION_TYPE = "Bearer";
     public static final String AUTHENTICATION_SUFFIX = "api/tokens/authenticate";
     public static final String BEARER_RESPONSE_KEY = "bearerToken";

--- a/src/main/java/com/synopsys/blackduck/upload/validation/UploadValidator.java
+++ b/src/main/java/com/synopsys/blackduck/upload/validation/UploadValidator.java
@@ -21,6 +21,8 @@ public class UploadValidator {
     public static final int MINIMUM_UPLOAD_CHUNK_SIZE = 1024 * 1024 * 5;
     // The maximum supported size of a file chunk that can be uploaded is 2 GB.
     public static final int MAXIMUM_UPLOAD_CHUNK_SIZE = 1024 * 1024 * (1024 - 1) * 2;
+    // The default chunk size, if no chunk size is provided, is 25 MB.
+    public static final int DEFAULT_UPLOAD_CHUNK_SIZE = 1024 * 1024 * 25;
     // The default minimum file size for initiating a multipart upload is 5 GB.
     public static final long DEFAULT_MULTIPART_UPLOAD_FILE_SIZE_THRESHOLD = 1024L * 1024L * 1024L * 5L;
     // The maximum supported total file size for blackduck-upload-common is 100 GB.

--- a/src/test/java/com/synopsys/blackduck/upload/client/UploaderConfigTest.java
+++ b/src/test/java/com/synopsys/blackduck/upload/client/UploaderConfigTest.java
@@ -75,6 +75,43 @@ class UploaderConfigTest {
     }
 
     @Test
+    void testOnlyRequiredValuesNull() {
+        // Blackduck URL, API Token, and trust cert are omitted from the builder
+        UploaderConfig.Builder uploaderConfigBuilder = UploaderConfig.createConfig(PROXY_INFO);
+        uploaderConfigBuilder
+            .setUploadChunkSize(UPLOAD_CHUNK_SIZE)
+            .setTimeoutInSeconds(TIMEOUT_IN_SECONDS)
+            .setMultipartUploadThreshold(MULTIPART_UPLOAD_THRESHOLD)
+            .setMultipartUploadPartRetryAttempts(UploadValidator.DEFAULT_MULTIPART_UPLOAD_PART_RETRY_ATTEMPTS)
+            .setMultipartUploadPartRetryInitialInterval(UploadValidator.DEFAULT_MULTIPART_UPLOAD_PART_RETRY_INITIAL_INTERVAL)
+            .setMultipartUploadTimeoutInMinutes(UploadValidator.DEFAULT_MULTIPART_UPLOAD_TIMEOUT_MINUTES);
+
+        IntegrationException integrationException = assertThrows(IntegrationException.class, uploaderConfigBuilder::build);
+        EnvironmentProperties.getRequiredPropertyKeys().forEach(key -> assertTrue(integrationException.getMessage().contains(key)));
+    }
+
+    @Test
+    void testNonRequiredValuesNull() {
+        UploaderConfig.Builder uploaderConfigBuilder = UploaderConfig.createConfig(PROXY_INFO);
+        uploaderConfigBuilder
+            .setAlwaysTrustServerCertificate(ALWAYS_TRUST_CERT)
+            .setBlackDuckUrl(httpUrl)
+            .setApiToken(API_TOKEN);
+
+        UploaderConfig uploaderConfig = assertDoesNotThrow(uploaderConfigBuilder::build);
+        assertEquals(PROXY_INFO, uploaderConfig.getProxyInfo());
+        assertEquals(ALWAYS_TRUST_CERT, uploaderConfig.isAlwaysTrustServerCertificate());
+        assertEquals(httpUrl, uploaderConfig.getBlackDuckUrl());
+        assertEquals(API_TOKEN, uploaderConfig.getApiToken());
+        assertEquals(UploadValidator.DEFAULT_UPLOAD_CHUNK_SIZE, uploaderConfig.getUploadChunkSize());
+        assertEquals(300, uploaderConfig.getTimeoutInSeconds());
+        assertEquals(UploadValidator.DEFAULT_MULTIPART_UPLOAD_FILE_SIZE_THRESHOLD, uploaderConfig.getMultipartUploadThreshold());
+        assertEquals(UploadValidator.DEFAULT_MULTIPART_UPLOAD_PART_RETRY_ATTEMPTS, uploaderConfig.getMultipartUploadPartRetryAttempts());
+        assertEquals(UploadValidator.DEFAULT_MULTIPART_UPLOAD_PART_RETRY_INITIAL_INTERVAL, uploaderConfig.getMultipartUploadPartRetryInitialInterval());
+        assertEquals(UploadValidator.DEFAULT_MULTIPART_UPLOAD_TIMEOUT_MINUTES, uploaderConfig.getMultipartUploadTimeoutInMinutes());
+    }
+
+    @Test
     void testBuildValidationChunkSize() {
         UploaderConfig.Builder uploaderConfigBuilder = UploaderConfig.createConfigFromEnvironment(PROXY_INFO);
         uploaderConfigBuilder.setUploadChunkSize(UPLOAD_CHUNK_SIZE);

--- a/src/test/java/com/synopsys/blackduck/upload/client/UploaderConfigTest.java
+++ b/src/test/java/com/synopsys/blackduck/upload/client/UploaderConfigTest.java
@@ -13,6 +13,7 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import com.synopsys.blackduck.upload.rest.BlackDuckHttpClient;
 import com.synopsys.blackduck.upload.validation.UploadValidator;
 import com.synopsys.integration.exception.IntegrationException;
 import com.synopsys.integration.rest.HttpUrl;
@@ -104,7 +105,7 @@ class UploaderConfigTest {
         assertEquals(httpUrl, uploaderConfig.getBlackDuckUrl());
         assertEquals(API_TOKEN, uploaderConfig.getApiToken());
         assertEquals(UploadValidator.DEFAULT_UPLOAD_CHUNK_SIZE, uploaderConfig.getUploadChunkSize());
-        assertEquals(300, uploaderConfig.getTimeoutInSeconds());
+        assertEquals(BlackDuckHttpClient.DEFAULT_BLACKDUCK_TIMEOUT_SECONDS, uploaderConfig.getTimeoutInSeconds());
         assertEquals(UploadValidator.DEFAULT_MULTIPART_UPLOAD_FILE_SIZE_THRESHOLD, uploaderConfig.getMultipartUploadThreshold());
         assertEquals(UploadValidator.DEFAULT_MULTIPART_UPLOAD_PART_RETRY_ATTEMPTS, uploaderConfig.getMultipartUploadPartRetryAttempts());
         assertEquals(UploadValidator.DEFAULT_MULTIPART_UPLOAD_PART_RETRY_INITIAL_INTERVAL, uploaderConfig.getMultipartUploadPartRetryInitialInterval());


### PR DESCRIPTION
This PR is focused on updating the following:

- Make the getter methods of UploaderConfig public, such that the client is able to get back the value if set previously or via environment and then returns the result or default if not set.
- Set the default values for the blackduck timeout to be 300 seconds if not specified.
- Set the default value for the uploadChunkSize to use 25 MB.