### PR TITLE
RDSQDRN-24: Add support for multipart container uploads

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ tasks.compileJava {
 }
 
 group 'com.synopsys.integration'
-version = '1.1.1-SNAPSHOT'
+version = '1.2.0-SNAPSHOT'
 
 apply plugin: 'com.synopsys.integration.library'
 

--- a/src/main/java/com/synopsys/blackduck/upload/client/uploaders/AbstractUploader.java
+++ b/src/main/java/com/synopsys/blackduck/upload/client/uploaders/AbstractUploader.java
@@ -78,6 +78,7 @@ public abstract class AbstractUploader<T extends UploadStatus> {
         return fileUploader.multipartUpload(
             multipartUploadFileMetadata,
             getMultipartUploadStartRequestHeaders(),
+            getMultipartUploadStartContentType(),
             getMultipartUploadStartRequest(() -> multipartUploadFileMetadata),
             createUploadStatus(),
             createUploadStatusError()
@@ -98,6 +99,13 @@ public abstract class AbstractUploader<T extends UploadStatus> {
      * @return a map of HTTP request headers.
      */
     protected abstract Map<String, String> getMultipartUploadStartRequestHeaders();
+
+    /**
+     * Retrieve the Content-Type for the multipart upload start request.
+     *
+     * @return the uploader Content-Type for upload start requests.
+     */
+    protected abstract String getMultipartUploadStartContentType();
 
     /**
      * Retrieve the body content for an HTTP multipart upload start request.

--- a/src/main/java/com/synopsys/blackduck/upload/client/uploaders/ArtifactsUploader.java
+++ b/src/main/java/com/synopsys/blackduck/upload/client/uploaders/ArtifactsUploader.java
@@ -60,8 +60,18 @@ public class ArtifactsUploader extends AbstractUploader<UploadStatus> {
     @Override
     protected Map<String, String> getMultipartUploadStartRequestHeaders() {
         Map<String, String> headers = new HashMap<>();
-        headers.put(HttpHeaders.CONTENT_TYPE, ContentTypes.APPLICATION_MULTIPART_UPLOAD_START_V1);
+        headers.put(HttpHeaders.CONTENT_TYPE, getMultipartUploadStartContentType());
         return headers;
+    }
+
+    /**
+     * Retrieve the Content-Type for the multipart artifacts upload start requests.
+     *
+     * @return the Content-Type for artifacts upload start requests.
+     */
+    @Override
+    protected String getMultipartUploadStartContentType() {
+        return ContentTypes.APPLICATION_MULTIPART_UPLOAD_START_V1;
     }
 
     /**

--- a/src/main/java/com/synopsys/blackduck/upload/client/uploaders/BinaryUploader.java
+++ b/src/main/java/com/synopsys/blackduck/upload/client/uploaders/BinaryUploader.java
@@ -82,8 +82,18 @@ public class BinaryUploader extends AbstractUploader<BinaryUploadStatus> {
     @Override
     protected Map<String, String> getMultipartUploadStartRequestHeaders() {
         Map<String, String> headers = new HashMap<>();
-        headers.put(HttpHeaders.CONTENT_TYPE, ContentTypes.APPLICATION_BINARY_MULTIPART_UPLOAD_START_V1);
+        headers.put(HttpHeaders.CONTENT_TYPE, getMultipartUploadStartContentType());
         return headers;
+    }
+
+    /**
+     * Retrieve the Content-Type for the multipart binary upload start requests.
+     *
+     * @return the Content-Type for binary upload start requests.
+     */
+    @Override
+    protected String getMultipartUploadStartContentType() {
+        return ContentTypes.APPLICATION_BINARY_MULTIPART_UPLOAD_START_V1;
     }
 
     /**

--- a/src/main/java/com/synopsys/blackduck/upload/client/uploaders/ContainerUploader.java
+++ b/src/main/java/com/synopsys/blackduck/upload/client/uploaders/ContainerUploader.java
@@ -14,7 +14,7 @@ import com.synopsys.blackduck.upload.file.FileUploader;
 import com.synopsys.blackduck.upload.file.model.MultipartUploadFileMetadata;
 import com.synopsys.blackduck.upload.rest.model.ContentTypes;
 import com.synopsys.blackduck.upload.rest.model.request.MultipartUploadStartRequest;
-import com.synopsys.blackduck.upload.rest.status.ContainerUploadStatus;
+import com.synopsys.blackduck.upload.rest.status.DefaultUploadStatus;
 import com.synopsys.blackduck.upload.rest.status.MutableResponseStatus;
 import com.synopsys.blackduck.upload.rest.status.UploadStatus;
 import com.synopsys.blackduck.upload.validation.UploadValidator;
@@ -31,7 +31,7 @@ import com.synopsys.integration.rest.response.Response;
  * @see FileUploader
  * @see UploadValidator
  */
-public class ContainerUploader extends AbstractUploader<ContainerUploadStatus> {
+public class ContainerUploader extends AbstractUploader<DefaultUploadStatus> {
 
     /**
      * Constructor for Container uploads.
@@ -101,11 +101,11 @@ public class ContainerUploader extends AbstractUploader<ContainerUploadStatus> {
      * @return a function that produces the {@link UploadStatus} or throws an exception.
      */
     @Override
-    protected ThrowingFunction<Response, ContainerUploadStatus, IntegrationException> createUploadStatus() {
+    protected ThrowingFunction<Response, DefaultUploadStatus, IntegrationException> createUploadStatus() {
         return response -> {
             int statusCode = response.getStatusCode();
             String statusMessage = response.getStatusMessage();
-            return new ContainerUploadStatus(statusCode, statusMessage, null);
+            return new DefaultUploadStatus(statusCode, statusMessage, null);
         };
     }
 
@@ -116,7 +116,7 @@ public class ContainerUploader extends AbstractUploader<ContainerUploadStatus> {
      * @return a function that produces the {@link UploadStatus} when an error has occurred.
      */
     @Override
-    protected BiFunction<MutableResponseStatus, IntegrationException, ContainerUploadStatus> createUploadStatusError() {
-        return (response, exception) -> new ContainerUploadStatus(response.getStatusCode(), response.getStatusMessage(), exception);
+    protected BiFunction<MutableResponseStatus, IntegrationException, DefaultUploadStatus> createUploadStatusError() {
+        return (response, exception) -> new DefaultUploadStatus(response.getStatusCode(), response.getStatusMessage(), exception);
     }
 }

--- a/src/main/java/com/synopsys/blackduck/upload/client/uploaders/ContainerUploader.java
+++ b/src/main/java/com/synopsys/blackduck/upload/client/uploaders/ContainerUploader.java
@@ -65,8 +65,18 @@ public class ContainerUploader extends AbstractUploader<ContainerUploadStatus> {
     @Override
     protected Map<String, String> getMultipartUploadStartRequestHeaders() {
         Map<String, String> headers = new HashMap<>();
-        headers.put(HttpHeaders.CONTENT_TYPE, ContentTypes.APPLICATION_MULTIPART_UPLOAD_START_V1);
+        headers.put(HttpHeaders.CONTENT_TYPE, getMultipartUploadStartContentType());
         return headers;
+    }
+
+    /**
+     * Retrieve the Content-Type for the multipart container upload start requests.
+     *
+     * @return the Content-Type for container upload start requests.
+     */
+    @Override
+    protected String getMultipartUploadStartContentType() {
+        return ContentTypes.APPLICATION_MULTIPART_UPLOAD_START_V1;
     }
 
     /**

--- a/src/main/java/com/synopsys/blackduck/upload/client/uploaders/ReversingLabUploader.java
+++ b/src/main/java/com/synopsys/blackduck/upload/client/uploaders/ReversingLabUploader.java
@@ -60,8 +60,18 @@ public class ReversingLabUploader extends AbstractUploader<UploadStatus> {
     @Override
     protected Map<String, String> getMultipartUploadStartRequestHeaders() {
         Map<String, String> headers = new HashMap<>();
-        headers.put(HttpHeaders.CONTENT_TYPE, ContentTypes.APPLICATION_MULTIPART_UPLOAD_START_V1);
+        headers.put(HttpHeaders.CONTENT_TYPE, getMultipartUploadStartContentType());
         return headers;
+    }
+
+    /**
+     * Retrieve the Content-Type for the multipart ReversingLab upload start requests.
+     *
+     * @return the Content-Type for ReversingLab upload start requests.
+     */
+    @Override
+    protected String getMultipartUploadStartContentType() {
+        return ContentTypes.APPLICATION_MULTIPART_UPLOAD_START_V1;
     }
 
     /**

--- a/src/main/java/com/synopsys/blackduck/upload/client/uploaders/ToolsUploader.java
+++ b/src/main/java/com/synopsys/blackduck/upload/client/uploaders/ToolsUploader.java
@@ -60,8 +60,18 @@ public class ToolsUploader extends AbstractUploader<UploadStatus> {
     @Override
     protected Map<String, String> getMultipartUploadStartRequestHeaders() {
         Map<String, String> headers = new HashMap<>();
-        headers.put(HttpHeaders.CONTENT_TYPE, ContentTypes.APPLICATION_MULTIPART_UPLOAD_START_V1);
+        headers.put(HttpHeaders.CONTENT_TYPE, getMultipartUploadStartContentType());
         return headers;
+    }
+
+    /**
+     * Retrieve the Content-Type for the multipart Tools upload start requests.
+     *
+     * @return the Content-Type for Tools upload start requests.
+     */
+    @Override
+    protected String getMultipartUploadStartContentType() {
+        return ContentTypes.APPLICATION_MULTIPART_UPLOAD_START_V1;
     }
 
     /**

--- a/src/main/java/com/synopsys/blackduck/upload/client/uploaders/UploaderFactory.java
+++ b/src/main/java/com/synopsys/blackduck/upload/client/uploaders/UploaderFactory.java
@@ -54,8 +54,13 @@ public class UploaderFactory {
         return new BinaryUploader(uploaderConfig.getUploadChunkSize(), createFileUploader(urlPrefix), createUploadValidator(), binaryScanRequestData);
     }
 
-    // TODO: Make public along with uncommenting test when ready
-    private ContainerUploader createContainerUploader(String urlPrefix) {
+    /**
+     * Construct the uploader for Container uploads.
+     *
+     * @param urlPrefix Used to create {@link UploadRequestPaths}.
+     * @return the {@link ContainerUploader} created.
+     */
+    public ContainerUploader createContainerUploader(String urlPrefix) {
         return new ContainerUploader(uploaderConfig.getUploadChunkSize(), createFileUploader(urlPrefix), createUploadValidator());
     }
 

--- a/src/main/java/com/synopsys/blackduck/upload/file/FileUploader.java
+++ b/src/main/java/com/synopsys/blackduck/upload/file/FileUploader.java
@@ -119,6 +119,7 @@ public class FileUploader {
      *
      * @param multipartUploadFileMetadata The {@link MultipartUploadFileMetadata} for the file to upload.
      * @param multipartUploadStartRequestHeaders A {@link Map} of headers for the multipart upload start request.
+     * @param multipartUploadStartContentType The Content-Type for the start request body.
      * @param multipartUploadStartRequest The data object for multipart upload start request.
      * @param uploadStatusFunction {@link ThrowingFunction} that generates the {@link UploadStatus} from the response.
      * @param uploadStatusErrorFunction {@link BiFunction} that generates the error {@link UploadStatus} from the response and exception thrown.
@@ -128,13 +129,14 @@ public class FileUploader {
     public <T extends UploadStatus> T multipartUpload(
         MultipartUploadFileMetadata multipartUploadFileMetadata,
         Map<String, String> multipartUploadStartRequestHeaders,
+        String multipartUploadStartContentType,
         MultipartUploadStartRequest multipartUploadStartRequest,
         ThrowingFunction<Response, T, IntegrationException> uploadStatusFunction,
         BiFunction<MutableResponseStatus, IntegrationException, T> uploadStatusErrorFunction
     ) {
         MutableResponseStatus mutableResponseStatus = new MutableResponseStatus(-1, "unknown status");
         try {
-            String uploadUrl = startMultipartUpload(mutableResponseStatus, multipartUploadStartRequestHeaders, multipartUploadStartRequest);
+            String uploadUrl = startMultipartUpload(mutableResponseStatus, multipartUploadStartRequestHeaders, multipartUploadStartContentType, multipartUploadStartRequest);
             Map<Integer, String> uploadedParts = multipartUploadParts(mutableResponseStatus, multipartUploadFileMetadata, uploadUrl);
             verifyAllPartsUploaded(multipartUploadFileMetadata, uploadedParts);
             return finishMultipartUpload(mutableResponseStatus, uploadUrl, uploadStatusFunction);
@@ -148,6 +150,7 @@ public class FileUploader {
      *
      * @param mutableResponseStatus A {@link MutableResponseStatus} with the status of the multipart upload.
      * @param startRequestHeaders A {@link Map} of headers for the multipart upload start request.
+     * @param multipartUploadStartContentType The Content-Type for the start request body.
      * @param multipartUploadStartRequest The data object for multipart upload start request.
      * @return Value of the upload url from Black Duck to be used for part uploads and assembly.
      * @throws IntegrationException if an error occurred while making the request to Black Duck.
@@ -155,6 +158,7 @@ public class FileUploader {
     protected String startMultipartUpload(
         MutableResponseStatus mutableResponseStatus,
         Map<String, String> startRequestHeaders,
+        String multipartUploadStartContentType,
         MultipartUploadStartRequest multipartUploadStartRequest
     ) throws IntegrationException {
         String requestPath = uploadRequestPaths.getMultipartUploadStartRequestPath();
@@ -166,7 +170,7 @@ public class FileUploader {
             .headers(startRequestHeaders)
             .bodyContent(new StringBodyContent(
                 gson.toJson(multipartUploadStartRequest),
-                ContentType.create(ContentTypes.APPLICATION_BINARY_MULTIPART_UPLOAD_START_V1)
+                ContentType.create(multipartUploadStartContentType)
             ));
 
         Request request = builder.build();

--- a/src/main/java/com/synopsys/blackduck/upload/rest/model/ContentTypes.java
+++ b/src/main/java/com/synopsys/blackduck/upload/rest/model/ContentTypes.java
@@ -16,6 +16,11 @@ public class ContentTypes {
      */
     public static final String APPLICATION_BINARY_MULTIPART_UPLOAD_START_V1 = "application/vnd.blackducksoftware.binary-multipart-upload-start-1+json";
 
+    /**
+     * The content type for performing a standard upload request of a container file to the Black Duck server.
+     */
+    public static final String APPLICATION_CONTAINER_SCAN_DATA_V1 = "application/vnd.blackducksoftware.container-scan-data-1+octet-stream";
+
     // Upload parts content types.
     /**
      * The content type for an upload request of part/chunks of the file up to the Black Duck server.

--- a/src/main/java/com/synopsys/blackduck/upload/rest/status/ContainerUploadStatus.java
+++ b/src/main/java/com/synopsys/blackduck/upload/rest/status/ContainerUploadStatus.java
@@ -1,0 +1,30 @@
+package com.synopsys.blackduck.upload.rest.status;
+
+import java.io.Serializable;
+
+import org.jetbrains.annotations.Nullable;
+
+import com.synopsys.integration.exception.IntegrationException;
+
+/**
+ * Class that represents the overall status of a multipart upload of a container file that is returned to a user.
+ * @see UploadStatus
+ */
+public class ContainerUploadStatus extends UploadStatus implements Serializable {
+
+    /**
+     * Constructor for the status of the multipart upload.
+     * @param statusCode    The HTTP status code that is the end result of the multipart upload when it terminated regardless of whether the upload is successful or not.
+     * @param statusMessage The HTTP status message that describes an error if an error occurred or a success message indicating the upload succeeded.
+     * @param exception     The exception that caused a failure of the upload if present, otherwise it is null for successful uploads.
+     */
+    public ContainerUploadStatus(final int statusCode, final String statusMessage, @Nullable final IntegrationException exception) {
+        super(statusCode, statusMessage, exception);
+    }
+
+    @Override
+    public boolean hasContent() {
+        // Container finish requests do not have a response body with content, therefore we return false here.
+        return false;
+    }
+}

--- a/src/main/java/com/synopsys/blackduck/upload/rest/status/DefaultUploadStatus.java
+++ b/src/main/java/com/synopsys/blackduck/upload/rest/status/DefaultUploadStatus.java
@@ -7,10 +7,10 @@ import org.jetbrains.annotations.Nullable;
 import com.synopsys.integration.exception.IntegrationException;
 
 /**
- * Class that represents the overall status of a multipart upload of a container file that is returned to a user.
+ * Class that represents the overall status of a multipart upload file that is returned to a user.
  * @see UploadStatus
  */
-public class ContainerUploadStatus extends UploadStatus implements Serializable {
+public class DefaultUploadStatus extends UploadStatus implements Serializable {
 
     /**
      * Constructor for the status of the multipart upload.
@@ -18,13 +18,13 @@ public class ContainerUploadStatus extends UploadStatus implements Serializable 
      * @param statusMessage The HTTP status message that describes an error if an error occurred or a success message indicating the upload succeeded.
      * @param exception     The exception that caused a failure of the upload if present, otherwise it is null for successful uploads.
      */
-    public ContainerUploadStatus(final int statusCode, final String statusMessage, @Nullable final IntegrationException exception) {
+    public DefaultUploadStatus(final int statusCode, final String statusMessage, @Nullable final IntegrationException exception) {
         super(statusCode, statusMessage, exception);
     }
 
     @Override
     public boolean hasContent() {
-        // Container finish requests do not have a response body with content, therefore we return false here.
+        // No content is returned in finish requests do not have a response body with content, therefore we return false here.
         return false;
     }
 }

--- a/src/test/java/com/synopsys/blackduck/upload/client/uploaders/ContainerUploaderTestIT.java
+++ b/src/test/java/com/synopsys/blackduck/upload/client/uploaders/ContainerUploaderTestIT.java
@@ -1,0 +1,85 @@
+package com.synopsys.blackduck.upload.client.uploaders;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Properties;
+import java.util.UUID;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.gson.Gson;
+import com.synopsys.blackduck.upload.client.UploaderConfig;
+import com.synopsys.blackduck.upload.generator.RandomByteContentFileGenerator;
+import com.synopsys.blackduck.upload.rest.status.ContainerUploadStatus;
+import com.synopsys.blackduck.upload.test.TestPropertyKey;
+import com.synopsys.integration.log.IntLogger;
+import com.synopsys.integration.log.Slf4jIntLogger;
+import com.synopsys.integration.properties.TestPropertiesManager;
+import com.synopsys.integration.rest.HttpUrl;
+import com.synopsys.integration.rest.proxy.ProxyInfo;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ContainerUploaderTestIT {
+    private static final TestPropertiesManager testPropertiesManager = TestPropertyKey.getPropertiesManager();
+    private static final Logger logger = LoggerFactory.getLogger(ContainerUploaderTestIT.class);
+    private static final IntLogger intLogger = new Slf4jIntLogger(logger);
+
+    private final Gson gson = new Gson();
+
+    private UploaderFactory uploaderFactory;
+    private Path generatedSampleFilePath;
+
+    @BeforeAll
+    void createSampleFile() throws IOException {
+        RandomByteContentFileGenerator randomByteContentFileGenerator = new RandomByteContentFileGenerator();
+        long fileSize = 1024 * 1024 * 15L;
+        generatedSampleFilePath = randomByteContentFileGenerator.generateFile(fileSize, ".tar").orElseThrow(() -> new IOException("Could not generate file"));
+    }
+
+    @BeforeEach
+    void init() {
+        System.setProperty("org.slf4j.simpleLogger.log.com.synopsys", "debug");
+        boolean bdbaAvailable = testPropertiesManager.getProperty(TestPropertyKey.BDBA_CONTAINER_AVAILABLE.getPropertyKey())
+            .map(Boolean::valueOf)
+            .orElse(false);
+        assumeTrue(bdbaAvailable);
+
+        String blackduckUrlString = assertDoesNotThrow(()
+            -> testPropertiesManager.getRequiredProperty(TestPropertyKey.TEST_BLACKDUCK_URL.getPropertyKey()));
+        HttpUrl blackduckUrl = assertDoesNotThrow(() -> new HttpUrl(blackduckUrlString));
+        String blackduckApiToken = assertDoesNotThrow(()
+            -> testPropertiesManager.getRequiredProperty(TestPropertyKey.TEST_BLACKDUCK_API_TOKEN.getPropertyKey()));
+
+
+        UploaderConfig.Builder uploaderConfigBuilder = UploaderConfig.createConfigFromProperties(ProxyInfo.NO_PROXY_INFO, new Properties());
+        uploaderConfigBuilder
+            .setUploadChunkSize(100)
+            .setAlwaysTrustServerCertificate(true)
+            .setBlackDuckUrl(blackduckUrl)
+            .setApiToken(blackduckApiToken);
+        UploaderConfig uploaderConfig = assertDoesNotThrow(uploaderConfigBuilder::build);
+        uploaderFactory = new UploaderFactory(uploaderConfig, intLogger, gson);
+    }
+
+    @Test
+    void testStandardUpload() {
+        ContainerUploader containerUploader = uploaderFactory.createContainerUploader(String.format("/api/storage/containers/%s", UUID.randomUUID()));
+        ContainerUploadStatus uploadStatus = assertDoesNotThrow(() -> containerUploader.upload(generatedSampleFilePath));
+        assertFalse(uploadStatus.isError());
+        assertEquals(HttpStatus.SC_CREATED, uploadStatus.getStatusCode());
+        // A container upload does not contain a response body, therefore there should be no content returned other than a 201 response code.
+        assertFalse(uploadStatus.hasContent());
+    }
+
+}

--- a/src/test/java/com/synopsys/blackduck/upload/client/uploaders/ContainerUploaderTestIT.java
+++ b/src/test/java/com/synopsys/blackduck/upload/client/uploaders/ContainerUploaderTestIT.java
@@ -22,7 +22,7 @@ import org.slf4j.LoggerFactory;
 import com.google.gson.Gson;
 import com.synopsys.blackduck.upload.client.UploaderConfig;
 import com.synopsys.blackduck.upload.generator.RandomByteContentFileGenerator;
-import com.synopsys.blackduck.upload.rest.status.ContainerUploadStatus;
+import com.synopsys.blackduck.upload.rest.status.DefaultUploadStatus;
 import com.synopsys.blackduck.upload.test.TestPropertyKey;
 import com.synopsys.integration.exception.IntegrationException;
 import com.synopsys.integration.log.IntLogger;
@@ -81,7 +81,7 @@ class ContainerUploaderTestIT {
         uploaderFactory = new UploaderFactory(uploaderConfig, intLogger, gson);
 
         ContainerUploader containerUploader = uploaderFactory.createContainerUploader(String.format("/api/storage/containers/%s", UUID.randomUUID()));
-        ContainerUploadStatus uploadStatus = assertDoesNotThrow(() -> containerUploader.upload(generatedSampleFilePath));
+        DefaultUploadStatus uploadStatus = assertDoesNotThrow(() -> containerUploader.upload(generatedSampleFilePath));
         assertFalse(uploadStatus.isError());
         assertEquals(HttpStatus.SC_CREATED, uploadStatus.getStatusCode());
         // A container upload does not contain a response body, therefore there should be no content returned other than a 201 response code.
@@ -98,7 +98,7 @@ class ContainerUploaderTestIT {
         uploaderFactory = new UploaderFactory(uploaderConfig, intLogger, gson);
 
         ContainerUploader containerUploader = uploaderFactory.createContainerUploader(String.format("/api/storage/containers/%s", UUID.randomUUID()));
-        ContainerUploadStatus uploadStatus = assertDoesNotThrow(() -> containerUploader.upload(generatedSampleFilePath));
+        DefaultUploadStatus uploadStatus = assertDoesNotThrow(() -> containerUploader.upload(generatedSampleFilePath));
         assertFalse(uploadStatus.isError());
         assertEquals(HttpStatus.SC_NO_CONTENT, uploadStatus.getStatusCode());
         assertFalse(uploadStatus.hasContent());

--- a/src/test/java/com/synopsys/blackduck/upload/client/uploaders/UploaderFactoryTest.java
+++ b/src/test/java/com/synopsys/blackduck/upload/client/uploaders/UploaderFactoryTest.java
@@ -47,10 +47,10 @@ public class UploaderFactoryTest {
         assertNotNull(uploaderFactory.createBinaryUploader(DUMMY_PREFIX_URL, new BinaryScanRequestData("projectName", "version", "codeLocationName", "https://code-location-uri")));
     }
 
-    //    @Test
-    //    void testCreateContainerUploader() {
-    //        assertNotNull(uploaderFactory.createContainerUploader(DUMMY_PREFIX_URL));
-    //    }
+    @Test
+    void testCreateContainerUploader() {
+        assertNotNull(uploaderFactory.createContainerUploader(DUMMY_PREFIX_URL));
+    }
     //
     //    @Test
     //    void testCreateReversingLabUploader() {

--- a/src/test/java/com/synopsys/blackduck/upload/file/FileUploaderTest.java
+++ b/src/test/java/com/synopsys/blackduck/upload/file/FileUploaderTest.java
@@ -22,6 +22,7 @@ import org.mockito.stubbing.OngoingStubbing;
 import com.google.gson.Gson;
 import com.synopsys.blackduck.upload.file.model.MultipartUploadFileMetadata;
 import com.synopsys.blackduck.upload.rest.BlackDuckHttpClient;
+import com.synopsys.blackduck.upload.rest.model.ContentTypes;
 import com.synopsys.blackduck.upload.rest.model.request.MultipartUploadStartRequest;
 import com.synopsys.blackduck.upload.rest.status.BinaryUploadStatus;
 import com.synopsys.blackduck.upload.rest.status.MutableResponseStatus;
@@ -144,7 +145,14 @@ class FileUploaderTest {
         // This simulates a scenario where a thread is dropped and is unrecoverable before an exception is created.
 
         FileUploader fileUploader = new FileUploader(mockHttpClient, uploadRequestPaths, 1, 0, 10);
-        BinaryUploadStatus binaryUploadStatus = fileUploader.multipartUpload(metaData, startRequestHeaders, multipartUploadStartRequest, null, testStatusErrorFunction);
+        BinaryUploadStatus binaryUploadStatus = fileUploader.multipartUpload(
+            metaData,
+            startRequestHeaders,
+            ContentTypes.APPLICATION_BINARY_MULTIPART_UPLOAD_START_V1,
+            multipartUploadStartRequest,
+            null,
+            testStatusErrorFunction
+        );
 
         assertTrue(binaryUploadStatus.isError());
         IntegrationException exception = binaryUploadStatus.getException().orElseThrow(() -> new AssertionError("Could not get response content when it was expected."));

--- a/src/test/java/com/synopsys/blackduck/upload/file/FileUploaderTestIT.java
+++ b/src/test/java/com/synopsys/blackduck/upload/file/FileUploaderTestIT.java
@@ -161,6 +161,7 @@ class FileUploaderTestIT {
         BinaryUploadStatus uploadStatus = fileUploader.multipartUpload(
             metaData,
             startRequestHeaders,
+            ContentTypes.APPLICATION_BINARY_MULTIPART_UPLOAD_START_V1,
             uploadStartRequest,
             createBinaryUploadStatusFunction(),
             createUploadStatusErrorFunction()
@@ -199,6 +200,7 @@ class FileUploaderTestIT {
         BinaryUploadStatus uploadStatus = fileUploader.multipartUpload(
             metaData,
             startRequestHeaders,
+            ContentTypes.APPLICATION_BINARY_MULTIPART_UPLOAD_START_V1,
             uploadStartRequest,
             createBinaryUploadStatusFunction(),
             createUploadStatusErrorFunction()
@@ -223,6 +225,7 @@ class FileUploaderTestIT {
         String startUploadUrl = fileUploader.startMultipartUpload(
             mutableResponseStatus,
             Map.of(HttpHeaders.CONTENT_TYPE, ContentTypes.APPLICATION_BINARY_MULTIPART_UPLOAD_START_V1),
+            ContentTypes.APPLICATION_BINARY_MULTIPART_UPLOAD_START_V1,
             uploadStartRequest
         );
         assertDoesNotThrow(() -> new URL(startUploadUrl).toURI());
@@ -239,6 +242,7 @@ class FileUploaderTestIT {
         String startUploadUrl = fileUploader.startMultipartUpload(
             mutableResponseStatus,
             Map.of(HttpHeaders.CONTENT_TYPE, ContentTypes.APPLICATION_BINARY_MULTIPART_UPLOAD_START_V1),
+            ContentTypes.APPLICATION_BINARY_MULTIPART_UPLOAD_START_V1,
             uploadStartRequest
         );
         Map<Integer, String> partsMap = fileUploader.multipartUploadParts(mutableResponseStatus, metaData, startUploadUrl);
@@ -279,6 +283,7 @@ class FileUploaderTestIT {
         String startUploadUrl = fileUploader.startMultipartUpload(
             mutableResponseStatus,
             Map.of(HttpHeaders.CONTENT_TYPE, ContentTypes.APPLICATION_BINARY_MULTIPART_UPLOAD_START_V1),
+            ContentTypes.APPLICATION_BINARY_MULTIPART_UPLOAD_START_V1,
             uploadStartRequest
         );
         Map<Integer, String> partsMap = fileUploader.multipartUploadParts(mutableResponseStatus, metaData, startUploadUrl);
@@ -318,6 +323,7 @@ class FileUploaderTestIT {
         String startUploadUrl = multipartFileUploader.startMultipartUpload(
             mutableResponseStatus,
             Map.of(HttpHeaders.CONTENT_TYPE, ContentTypes.APPLICATION_BINARY_MULTIPART_UPLOAD_START_V1),
+            ContentTypes.APPLICATION_BINARY_MULTIPART_UPLOAD_START_V1,
             uploadStartRequest
         );
         Map<Integer, String> partsMap = multipartFileUploader.multipartUploadParts(mutableResponseStatus, invalidMetadata, startUploadUrl);
@@ -336,6 +342,7 @@ class FileUploaderTestIT {
         String startUploadUrl = fileUploader.startMultipartUpload(
             mutableResponseStatus,
             Map.of(HttpHeaders.CONTENT_TYPE, ContentTypes.APPLICATION_BINARY_MULTIPART_UPLOAD_START_V1),
+            ContentTypes.APPLICATION_BINARY_MULTIPART_UPLOAD_START_V1,
             uploadStartRequest
         );
         Map<Integer, String> partsMap = fileUploader.multipartUploadParts(mutableResponseStatus, metaData, startUploadUrl);
@@ -374,6 +381,7 @@ class FileUploaderTestIT {
         String startUploadUrl = fileUploader.startMultipartUpload(
             mutableResponseStatus,
             Map.of(HttpHeaders.CONTENT_TYPE, ContentTypes.APPLICATION_BINARY_MULTIPART_UPLOAD_START_V1),
+            ContentTypes.APPLICATION_BINARY_MULTIPART_UPLOAD_START_V1,
             uploadStartRequest
         );
         Map<Integer, String> partsMap = fileUploader.multipartUploadParts(mutableResponseStatus, invalidMetadata, startUploadUrl);

--- a/src/test/java/com/synopsys/blackduck/upload/generator/RandomByteContentFileGenerator.java
+++ b/src/test/java/com/synopsys/blackduck/upload/generator/RandomByteContentFileGenerator.java
@@ -1,0 +1,61 @@
+package com.synopsys.blackduck.upload.generator;
+
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.Random;
+import java.util.UUID;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RandomByteContentFileGenerator {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private final Random randomGenerator = new Random();
+
+    public Optional<Path> generateFile(long generatedFileSize) throws IOException {
+        return generateFile(generatedFileSize, ".tmp");
+    }
+
+    public Optional<Path> generateFile(long generatedFileSize, String fileExtension) throws IOException {
+        Path result = null;
+        if (generatedFileSize > 0) {
+            Path generatedTempFilePath  = generatedTempFile(fileExtension);
+            logger.info("====================================================");
+            logger.info("Random Byte Content File Generation:");
+            logger.info("  File size(bytes): {}", generatedFileSize);
+            logger.info("  File path:        {}", generatedTempFilePath);
+            try(RandomAccessFile generatedFile = new RandomAccessFile(generatedTempFilePath.toFile(),"rw");
+                FileChannel fileChannel = generatedFile.getChannel()) {
+                // set the capacity for the byte buffer
+                int capacity = generatedFileSize < 1024 ? (int) generatedFileSize : 1024;
+                ByteBuffer byteBuffer = ByteBuffer.allocate(capacity);
+                int numberOfBytesWritten = 0;
+                while(numberOfBytesWritten < generatedFileSize) {
+                    // assign random bytes to the file.
+                    randomGenerator.nextBytes(byteBuffer.array());
+                    numberOfBytesWritten += fileChannel.write(byteBuffer);
+                    byteBuffer.clear();
+                }
+                // truncate the file contents to the generated file length in case more bytes were written to the file.
+                generatedFile.setLength(generatedFileSize);
+                result = generatedTempFilePath;
+            } finally {
+                logger.info("====================================================");
+            }
+        }
+        return Optional.ofNullable(result);
+    }
+
+    private Path generatedTempFile(String fileExtension) throws IOException {
+        String fileName = String.format("generated_%s", UUID.randomUUID());
+        Path generatedTempFilePath  = Files.createTempFile(fileName, fileExtension);
+        // delete the file from the temp directory after the JVM shuts down.
+        generatedTempFilePath.toFile().deleteOnExit();
+        return generatedTempFilePath;
+    }
+}


### PR DESCRIPTION
This MR completes the following tasks:

- Updates the library to 1.2.0
- Added new abstract method for getting content types for body encoding into the AbstractUploader
- Added support for the ContainerUploader
- Added test coverage for ContainerUploader
- Added RandomByteContentFileGenerator for generating files for tests that will clean up after the test
  - This will be extended to other tests in a future MR