### PR TITLE
RDSQDRN-40: Rename blackduck timeout

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ tasks.compileJava {
 }
 
 group 'com.synopsys.integration'
-version = '1.1.1-SNAPSHOT'
+version = '2.0.0-SNAPSHOT'
 
 apply plugin: 'com.synopsys.integration.library'
 

--- a/src/main/java/com/synopsys/blackduck/upload/client/UploaderConfig.java
+++ b/src/main/java/com/synopsys/blackduck/upload/client/UploaderConfig.java
@@ -26,7 +26,7 @@ import com.synopsys.integration.rest.proxy.ProxyInfo;
 public class UploaderConfig {
     private final ProxyInfo proxyInfo;
     private final int uploadChunkSize;
-    private final int timeoutInSeconds;
+    private final int blackduckTimeoutInSeconds;
     private final boolean alwaysTrustServerCertificate;
     private final HttpUrl blackDuckUrl;
     private final String apiToken;
@@ -109,7 +109,7 @@ public class UploaderConfig {
     private UploaderConfig(
         ProxyInfo proxyInfo,
         int uploadChunkSize,
-        int timeoutInSeconds,
+        int blackduckTimeoutInSeconds,
         boolean alwaysTrustServerCertificate,
         HttpUrl blackDuckUrl,
         String apiToken,
@@ -120,7 +120,7 @@ public class UploaderConfig {
     ) {
         this.proxyInfo = proxyInfo;
         this.uploadChunkSize = uploadChunkSize;
-        this.timeoutInSeconds = timeoutInSeconds;
+        this.blackduckTimeoutInSeconds = blackduckTimeoutInSeconds;
         this.alwaysTrustServerCertificate = alwaysTrustServerCertificate;
         this.blackDuckUrl = blackDuckUrl;
         this.apiToken = apiToken;
@@ -153,8 +153,8 @@ public class UploaderConfig {
      *
      * @return timeout in seconds.
      */
-    public int getTimeoutInSeconds() {
-        return timeoutInSeconds;
+    public int getBlackDuckTimeoutInSeconds() {
+        return blackduckTimeoutInSeconds;
     }
 
     /**
@@ -246,7 +246,7 @@ public class UploaderConfig {
             return new UploaderConfig(
                 proxyInfo,
                 getUploadChunkSize(),
-                getTimeoutInSeconds(),
+                getBlackDuckTimeoutInSeconds(),
                 isAlwaysTrustServerCertificate(),
                 getBlackDuckUrl().orElse(null),
                 getApiToken().orElse(null),
@@ -285,7 +285,7 @@ public class UploaderConfig {
          *
          * @return configured or default timeout in seconds.
          */
-        public int getTimeoutInSeconds() {
+        public int getBlackDuckTimeoutInSeconds() {
             Optional<String> timeoutInSeconds = Optional.ofNullable(getPropertyValue(EnvironmentProperties.BLACKDUCK_TIMEOUT_SECONDS.getPropertyKey()));
             return timeoutInSeconds.map(Integer::parseInt).orElse(BlackDuckHttpClient.DEFAULT_BLACKDUCK_TIMEOUT_SECONDS);
         }
@@ -408,23 +408,23 @@ public class UploaderConfig {
         /**
          * Replace the timeout when communicating with Black Duck.
          *
-         * @param timeoutInSeconds The time to wait for a response.
+         * @param blackduckTimeoutInSeconds The time to wait for a response.
          *
          * @return builder.
          */
-        public Builder setTimeoutInSeconds(int timeoutInSeconds) {
-            return setTimeoutInSeconds(String.valueOf(timeoutInSeconds));
+        public Builder setBlackDuckTimeoutInSeconds(int blackduckTimeoutInSeconds) {
+            return setBlackDuckTimeoutInSeconds(String.valueOf(blackduckTimeoutInSeconds));
         }
 
         /**
          * Replace the timeout when communicating with Black Duck.
          *
-         * @param timeoutInSeconds The time to wait for a response.
+         * @param blackduckTimeoutInSeconds The time to wait for a response.
          *
          * @return builder.
          */
-        public Builder setTimeoutInSeconds(String timeoutInSeconds) {
-            setPropertyValue(EnvironmentProperties.BLACKDUCK_TIMEOUT_SECONDS, timeoutInSeconds);
+        public Builder setBlackDuckTimeoutInSeconds(String blackduckTimeoutInSeconds) {
+            setPropertyValue(EnvironmentProperties.BLACKDUCK_TIMEOUT_SECONDS, blackduckTimeoutInSeconds);
             return this;
         }
 

--- a/src/main/java/com/synopsys/blackduck/upload/client/uploaders/UploaderFactory.java
+++ b/src/main/java/com/synopsys/blackduck/upload/client/uploaders/UploaderFactory.java
@@ -83,7 +83,7 @@ public class UploaderFactory {
         return new BlackDuckHttpClient(
             intLogger,
             gson,
-            uploaderConfig.getTimeoutInSeconds(),
+            uploaderConfig.getBlackDuckTimeoutInSeconds(),
             uploaderConfig.isAlwaysTrustServerCertificate(),
             uploaderConfig.getProxyInfo(),
             uploaderConfig.getBlackDuckUrl(),

--- a/src/test/java/com/synopsys/blackduck/upload/client/UploaderConfigTest.java
+++ b/src/test/java/com/synopsys/blackduck/upload/client/UploaderConfigTest.java
@@ -22,7 +22,7 @@ import com.synopsys.integration.rest.proxy.ProxyInfo;
 class UploaderConfigTest {
     private static final ProxyInfo PROXY_INFO = ProxyInfo.NO_PROXY_INFO;
     private static final int UPLOAD_CHUNK_SIZE = 31339;
-    private static final int TIMEOUT_IN_SECONDS = 30;
+    private static final int BLACKDUCK_TIMEOUT_IN_SECONDS = 30;
     private static final boolean ALWAYS_TRUST_CERT = false;
     private static final String HTTP_URL_STRING = "https://somewhere.com";
     private static final String API_TOKEN = "ThisTsNotAValidToken";
@@ -46,7 +46,7 @@ class UploaderConfigTest {
         UploaderConfig.Builder uploaderConfigBuilder = UploaderConfig.createConfigFromProperties(PROXY_INFO, new Properties());
         uploaderConfigBuilder
             .setUploadChunkSize(UPLOAD_CHUNK_SIZE)
-            .setTimeoutInSeconds(TIMEOUT_IN_SECONDS)
+            .setBlackDuckTimeoutInSeconds(BLACKDUCK_TIMEOUT_IN_SECONDS)
             .setAlwaysTrustServerCertificate(ALWAYS_TRUST_CERT)
             .setBlackDuckUrl(httpUrl)
             .setApiToken(API_TOKEN)
@@ -58,7 +58,7 @@ class UploaderConfigTest {
         UploaderConfig uploaderConfig = assertDoesNotThrow(uploaderConfigBuilder::build);
         assertEquals(PROXY_INFO, uploaderConfig.getProxyInfo());
         assertEquals(UPLOAD_CHUNK_SIZE, uploaderConfig.getUploadChunkSize());
-        assertEquals(TIMEOUT_IN_SECONDS, uploaderConfig.getTimeoutInSeconds());
+        assertEquals(BLACKDUCK_TIMEOUT_IN_SECONDS, uploaderConfig.getBlackDuckTimeoutInSeconds());
         assertEquals(ALWAYS_TRUST_CERT, uploaderConfig.isAlwaysTrustServerCertificate());
         assertEquals(httpUrl, uploaderConfig.getBlackDuckUrl());
         assertEquals(API_TOKEN, uploaderConfig.getApiToken());
@@ -81,7 +81,7 @@ class UploaderConfigTest {
         UploaderConfig.Builder uploaderConfigBuilder = UploaderConfig.createConfig(PROXY_INFO);
         uploaderConfigBuilder
             .setUploadChunkSize(UPLOAD_CHUNK_SIZE)
-            .setTimeoutInSeconds(TIMEOUT_IN_SECONDS)
+            .setBlackDuckTimeoutInSeconds(BLACKDUCK_TIMEOUT_IN_SECONDS)
             .setMultipartUploadThreshold(MULTIPART_UPLOAD_THRESHOLD)
             .setMultipartUploadPartRetryAttempts(UploadValidator.DEFAULT_MULTIPART_UPLOAD_PART_RETRY_ATTEMPTS)
             .setMultipartUploadPartRetryInitialInterval(UploadValidator.DEFAULT_MULTIPART_UPLOAD_PART_RETRY_INITIAL_INTERVAL)
@@ -105,7 +105,7 @@ class UploaderConfigTest {
         assertEquals(httpUrl, uploaderConfig.getBlackDuckUrl());
         assertEquals(API_TOKEN, uploaderConfig.getApiToken());
         assertEquals(UploadValidator.DEFAULT_UPLOAD_CHUNK_SIZE, uploaderConfig.getUploadChunkSize());
-        assertEquals(BlackDuckHttpClient.DEFAULT_BLACKDUCK_TIMEOUT_SECONDS, uploaderConfig.getTimeoutInSeconds());
+        assertEquals(BlackDuckHttpClient.DEFAULT_BLACKDUCK_TIMEOUT_SECONDS, uploaderConfig.getBlackDuckTimeoutInSeconds());
         assertEquals(UploadValidator.DEFAULT_MULTIPART_UPLOAD_FILE_SIZE_THRESHOLD, uploaderConfig.getMultipartUploadThreshold());
         assertEquals(UploadValidator.DEFAULT_MULTIPART_UPLOAD_PART_RETRY_ATTEMPTS, uploaderConfig.getMultipartUploadPartRetryAttempts());
         assertEquals(UploadValidator.DEFAULT_MULTIPART_UPLOAD_PART_RETRY_INITIAL_INTERVAL, uploaderConfig.getMultipartUploadPartRetryInitialInterval());
@@ -123,7 +123,7 @@ class UploaderConfigTest {
     @Test
     void testBuildValidationTimeout() {
         UploaderConfig.Builder uploaderConfigBuilder = assertDoesNotThrow(() -> UploaderConfig.createConfigFromFile(PROXY_INFO, testPropertiesFile));
-        uploaderConfigBuilder.setTimeoutInSeconds(TIMEOUT_IN_SECONDS);
+        uploaderConfigBuilder.setBlackDuckTimeoutInSeconds(BLACKDUCK_TIMEOUT_IN_SECONDS);
         IntegrationException integrationException = assertThrows(IntegrationException.class, uploaderConfigBuilder::build);
         assertFalse(integrationException.getMessage().contains(EnvironmentProperties.BLACKDUCK_TIMEOUT_SECONDS.getPropertyKey()));
     }

--- a/src/test/java/com/synopsys/blackduck/upload/client/uploaders/UploaderFactoryTest.java
+++ b/src/test/java/com/synopsys/blackduck/upload/client/uploaders/UploaderFactoryTest.java
@@ -29,7 +29,7 @@ public class UploaderFactoryTest {
         UploaderConfig.Builder uploaderConfigBuilder = UploaderConfig.createConfigFromProperties(ProxyInfo.NO_PROXY_INFO, new Properties());
         uploaderConfigBuilder
             .setUploadChunkSize(39)
-            .setTimeoutInSeconds(13)
+            .setBlackDuckTimeoutInSeconds(13)
             .setAlwaysTrustServerCertificate(false)
             .setBlackDuckUrl("https://somewhere.com")
             .setApiToken("ThisTsNotAValidToken");


### PR DESCRIPTION
Renaming the blackduck timeout in order to be more explicit in what each timeout is for.

As this is a breaking change, the version of the library is bumped to 2.0.0.