### PR TITLE
RDSQDRN-45: Clean up logging to be less verbose

### DIFF
--- a/src/main/java/com/blackduck/integration/sca/upload/file/FileUploader.java
+++ b/src/main/java/com/blackduck/integration/sca/upload/file/FileUploader.java
@@ -340,7 +340,8 @@ public class FileUploader {
             }
         } catch (IOException | IntegrationException ex) {
             logger.error("Exception occurred whiling uploading part {}", part);
-            logger.error("Cause: ", ex);
+            logger.error("Cause: {}", ex.getMessage());
+            logger.debug("Cause: ", ex);
         }
         return Optional.empty();
     }
@@ -413,7 +414,8 @@ public class FileUploader {
             }
         } catch (IntegrationException | IOException ex) {
             logger.error("Error canceling upload");
-            logger.error("Cause", ex);
+            logger.error("Cause: {}", ex.getMessage());
+            logger.debug("Cause: ", ex);
         }
         isCanceled = true;
     }


### PR DESCRIPTION
Through Detect it was found that our logging for errors that occur during uploads may be too noisy and is throwing large stack traces. To the end user, they like don't care about the stack trace and line at which the error was produced but primarily would care about what the message is.

To clean this up, this PR switches the logging to log only the message at ERROR level.
If a client switches to DEBUG logging level they will still get the full stack trace