### PR TITLE
Ensure Case-Insensitive Handling of `ETag` Header in Binary Scan Upload  

### DIFF
--- a/src/main/java/com/blackduck/integration/sca/upload/client/uploaders/BinaryUploader.java
+++ b/src/main/java/com/blackduck/integration/sca/upload/client/uploaders/BinaryUploader.java
@@ -137,7 +137,7 @@ public class BinaryUploader extends AbstractUploader<BinaryUploadStatus> {
             Map<String, String> responseHeaders = response.getHeaders();
             String location = Optional.ofNullable(responseHeaders.get(HttpHeaders.LOCATION)).orElseThrow(() -> new IntegrationException("Could not find Location header."));
             String eTag = responseHeaders.entrySet().stream()
-                .filter(entry -> entry.getKey().equalsIgnoreCase("ETag")) // Case-insensitive match
+                .filter(entry -> entry.getKey().equalsIgnoreCase(HttpHeaders.ETAG))
                 .map(Map.Entry::getValue)
                 .findFirst()
                 .orElseThrow(() -> new IntegrationException("Could not find ETag header."));

--- a/src/main/java/com/blackduck/integration/sca/upload/client/uploaders/BinaryUploader.java
+++ b/src/main/java/com/blackduck/integration/sca/upload/client/uploaders/BinaryUploader.java
@@ -136,7 +136,12 @@ public class BinaryUploader extends AbstractUploader<BinaryUploadStatus> {
 
             Map<String, String> responseHeaders = response.getHeaders();
             String location = Optional.ofNullable(responseHeaders.get(HttpHeaders.LOCATION)).orElseThrow(() -> new IntegrationException("Could not find Location header."));
-            String eTag = Optional.ofNullable(responseHeaders.get(HttpHeaders.ETAG)).orElseThrow(() -> new IntegrationException("Could not find Etag header."));
+            String eTag = responseHeaders.entrySet().stream()
+                .filter(entry -> entry.getKey().equalsIgnoreCase("ETag")) // Case-insensitive match
+                .map(Map.Entry::getValue)
+                .findFirst()
+                .orElseThrow(() -> new IntegrationException("Could not find ETag header."));
+
             BinaryFinishResponseContent binaryFinishResponseContent = new BinaryFinishResponseContent(location, eTag);
 
             return new BinaryUploadStatus(statusCode, statusMessage, null, binaryFinishResponseContent);

--- a/src/test/java/com/blackduck/integration/sca/upload/client/uploaders/BinaryUploaderHeaderTest.java
+++ b/src/test/java/com/blackduck/integration/sca/upload/client/uploaders/BinaryUploaderHeaderTest.java
@@ -1,0 +1,61 @@
+package com.blackduck.integration.sca.upload.client.uploaders;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.http.HttpHeaders;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.blackduck.integration.rest.response.Response;
+import com.blackduck.integration.sca.upload.client.model.BinaryScanRequestData;
+import com.blackduck.integration.sca.upload.file.FileUploader;
+import com.blackduck.integration.sca.upload.rest.status.BinaryUploadStatus;
+import com.blackduck.integration.sca.upload.validation.UploadValidator;
+
+class BinaryUploaderHeaderTest {
+    
+    private static final String LOCATION_URL = "https://example.com/upload/123";
+    private static final String EXPECTED_ETAG = "\"a5dd8dec-cb28-473c-a269-738faa6a2b84\"";
+    private static final int EXPECTED_STATUS_CODE = 201;
+    private static final String EXPECTED_STATUS_MESSAGE = "Created";
+    
+    private static final String[] ETAG_VARIANTS = {"ETag", "Etag"}; // Case variations for testing
+
+    @Test
+    void testCreateUploadStatus_CaseInsensitiveETag() throws Exception {
+        FileUploader mockFileUploader = mock(FileUploader.class);
+        UploadValidator mockUploadValidator = mock(UploadValidator.class);
+        BinaryScanRequestData mockBinaryScanRequestData = mock(BinaryScanRequestData.class);
+        Response mockResponse = mock(Response.class);
+
+        BinaryUploader binaryUploader = new BinaryUploader(1000, mockFileUploader, mockUploadValidator, mockBinaryScanRequestData);
+
+        int expectedHeadersCalls = ETAG_VARIANTS.length;
+
+        for (String eTagVariant : ETAG_VARIANTS) {
+            Map<String, String> headers = new HashMap<>();
+            headers.put(HttpHeaders.LOCATION, LOCATION_URL);
+            headers.put(eTagVariant, EXPECTED_ETAG); // Varying ETag case
+
+            when(mockResponse.getStatusCode()).thenReturn(EXPECTED_STATUS_CODE);
+            when(mockResponse.getStatusMessage()).thenReturn(EXPECTED_STATUS_MESSAGE);
+            when(mockResponse.getHeaders()).thenReturn(headers);
+
+            BinaryUploadStatus status = binaryUploader.createUploadStatus().apply(mockResponse);
+
+            assertEquals(EXPECTED_STATUS_CODE, status.getStatusCode());
+            assertEquals(EXPECTED_STATUS_MESSAGE, status.getStatusMessage());
+            assertTrue(status.getResponseContent().isPresent(), "Response content should be present");
+            assertEquals(LOCATION_URL, status.getResponseContent().orElseThrow().getLocation());
+            assertEquals(EXPECTED_ETAG, status.getResponseContent().orElseThrow().getETag());
+        }
+
+        verify(mockResponse, times(expectedHeadersCalls)).getHeaders();
+    }
+}


### PR DESCRIPTION
### **JIRA Ticket:**  
[IDETECT-4599](https://blackduck.atlassian.net/browse/IDETECT-4599)  

## **Description:**  
This PR fixes an issue where the `ETag` response header was handled in a **case-sensitive** manner in `BinaryUploader#createUploadStatus()`, causing **binary scan uploads to fail** when the header was modified by a reverse proxy (e.g., **Traefik changes `ETag` to `Etag`**).  

### **Changes Introduced:**  
- Updated `BinaryUploader#createUploadStatus()` to handle the `ETag` header **case-insensitively**.  
- Added a **unit test to verify case-insensitive `ETag` handling**.  

### **Impact on Detect:**  
The Detect tool relies on `BinaryUploader#createUploadStatus()`, which is part of **blackduck-upload-common** and is responsible for **uploading and extracting headers**. Since `createUploadStatus()` previously handled `ETag` case-sensitively, Detect’s **binary scan uploads were failing** when proxies altered the header’s casing.  

This issue was **specifically observed when using Traefik as a reverse proxy**, where the `ETag` header’s casing was modified, leading to failed binary scans.  

This fix ensures that Detect’s **binary scan uploads succeed regardless of header casing**.  

### **Reviewer Notes:**  
- **Minimal impact**—only modifies `ETag` extraction logic.  
- **No breaking changes**—this only affects response parsing for binary uploads.  
- Fix is critical since **Detect binary scans were failing due to this issue while using Traefik as a reverse proxy**.  

Would appreciate a review and feedback!
