### PR TITLE
fix(scass uploader): Add proxy info to upload client (IDETECT-4921)

### DIFF
--- a/src/main/java/com/blackduck/integration/sca/upload/client/uploaders/UploaderFactory.java
+++ b/src/main/java/com/blackduck/integration/sca/upload/client/uploaders/UploaderFactory.java
@@ -95,6 +95,14 @@ public class UploaderFactory {
         );
     }
 
+    public ScassUploader createScassUploaderWithProxyInfo() {
+        return new ScassUploader(createScassHttpClientWithProxyInfo(), createUploadValidator(),
+                uploaderConfig.getUploadChunkSize(),
+                uploaderConfig.getMultipartUploadPartRetryInitialInterval(),
+                uploaderConfig.getMultipartUploadPartRetryAttempts()
+        );
+    }
+
     // TODO: Make public along with uncommenting test when ready
     private ReversingLabUploader createReversingLabUploader(String urlPrefix) {
         return new ReversingLabUploader(uploaderConfig.getUploadChunkSize(), createFileUploader(urlPrefix), createUploadValidator());
@@ -134,6 +142,16 @@ public class UploaderFactory {
             uploaderConfig.getBlackDuckTimeoutInSeconds(),
             uploaderConfig.isAlwaysTrustServerCertificate(),
             ProxyInfo.NO_PROXY_INFO
+        );
+    }
+
+    private IntHttpClient createScassHttpClientWithProxyInfo() {
+        return new IntHttpClient(
+                intLogger,
+                gson,
+                uploaderConfig.getBlackDuckTimeoutInSeconds(),
+                uploaderConfig.isAlwaysTrustServerCertificate(),
+                this.uploaderConfig.getProxyInfo()
         );
     }
 

--- a/src/main/java/com/blackduck/integration/sca/upload/client/uploaders/UploaderFactory.java
+++ b/src/main/java/com/blackduck/integration/sca/upload/client/uploaders/UploaderFactory.java
@@ -87,14 +87,6 @@ public class UploaderFactory {
      * Construct the uploader for SCASS uploads.
      * @return the {@link ScassUploader} created.
      */
-    public ScassUploader createScassUploader() {
-        return new ScassUploader(createScassHttpClient(), createUploadValidator(),
-            uploaderConfig.getUploadChunkSize(),
-            uploaderConfig.getMultipartUploadPartRetryInitialInterval(),
-            uploaderConfig.getMultipartUploadPartRetryAttempts()
-        );
-    }
-
     public ScassUploader createScassUploaderWithProxyInfo() {
         return new ScassUploader(createScassHttpClientWithProxyInfo(), createUploadValidator(),
                 uploaderConfig.getUploadChunkSize(),
@@ -132,16 +124,6 @@ public class UploaderFactory {
             uploaderConfig.getProxyInfo(),
             uploaderConfig.getBlackDuckUrl(),
             uploaderConfig.getApiToken()
-        );
-    }
-
-    private IntHttpClient createScassHttpClient() {
-        return new IntHttpClient(
-            intLogger,
-            gson,
-            uploaderConfig.getBlackDuckTimeoutInSeconds(),
-            uploaderConfig.isAlwaysTrustServerCertificate(),
-            ProxyInfo.NO_PROXY_INFO
         );
     }
 

--- a/src/main/java/com/blackduck/integration/sca/upload/client/uploaders/UploaderFactory.java
+++ b/src/main/java/com/blackduck/integration/sca/upload/client/uploaders/UploaderFactory.java
@@ -89,9 +89,9 @@ public class UploaderFactory {
      */
     public ScassUploader createScassUploaderWithProxyInfo() {
         return new ScassUploader(createScassHttpClientWithProxyInfo(), createUploadValidator(),
-                uploaderConfig.getUploadChunkSize(),
-                uploaderConfig.getMultipartUploadPartRetryInitialInterval(),
-                uploaderConfig.getMultipartUploadPartRetryAttempts()
+            uploaderConfig.getUploadChunkSize(),
+            uploaderConfig.getMultipartUploadPartRetryInitialInterval(),
+            uploaderConfig.getMultipartUploadPartRetryAttempts()
         );
     }
 
@@ -129,10 +129,10 @@ public class UploaderFactory {
 
     private IntHttpClient createScassHttpClientWithProxyInfo() {
         return new IntHttpClient(
-                intLogger,
-                gson,
-                uploaderConfig.getBlackDuckTimeoutInSeconds(),
-                uploaderConfig.isAlwaysTrustServerCertificate(),
+            intLogger,
+            gson,
+            uploaderConfig.getBlackDuckTimeoutInSeconds(),
+            uploaderConfig.isAlwaysTrustServerCertificate(),
                 this.uploaderConfig.getProxyInfo()
         );
     }


### PR DESCRIPTION
See IDETECT-4921 for more details. 
Corresponding Detect MR: https://github.com/blackducksoftware/detect/pull/1611

Summary: 
Before this, we did not pass through the proxy info all the way to the SCASS uploader client creation. With this change, SCASS upload URLs will flow through the configured proxy (on Detect side via blackduck.proxy.host=... and blackduck.proxy.port=...)