### PR TITLE
add case insensitive header lookup for SCASS based scans

### DIFF
--- a/src/main/java/com/blackduck/integration/sca/upload/client/uploaders/BinaryUploader.java
+++ b/src/main/java/com/blackduck/integration/sca/upload/client/uploaders/BinaryUploader.java
@@ -12,7 +12,6 @@ import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.TreeMap;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
@@ -33,6 +32,7 @@ import com.blackduck.integration.sca.upload.rest.model.response.BinaryFinishResp
 import com.blackduck.integration.sca.upload.rest.status.BinaryUploadStatus;
 import com.blackduck.integration.sca.upload.rest.status.MutableResponseStatus;
 import com.blackduck.integration.sca.upload.rest.status.UploadStatus;
+import com.blackduck.integration.sca.upload.util.HttpHeaderUtils;
 import com.blackduck.integration.sca.upload.validation.UploadValidator;
 
 /**
@@ -136,10 +136,7 @@ public class BinaryUploader extends AbstractUploader<BinaryUploadStatus> {
             String statusMessage = response.getStatusMessage();
 
             Map<String, String> responseHeaders = response.getHeaders();
-            Map<String, String> caseInsensitiveHeaders = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
-            caseInsensitiveHeaders.putAll(responseHeaders);
-
-            String location = Optional.ofNullable(caseInsensitiveHeaders.get(HttpHeaders.LOCATION))
+            String location = Optional.ofNullable(HttpHeaderUtils.getHeaderCaseInsensitive(responseHeaders, HttpHeaders.LOCATION))
                 .orElseThrow(() -> new IntegrationException("Could not find Location header."));
             String eTag = responseHeaders.entrySet().stream()
                 .filter(entry -> entry.getKey().equalsIgnoreCase(HttpHeaders.ETAG))

--- a/src/main/java/com/blackduck/integration/sca/upload/client/uploaders/ScassUploader.java
+++ b/src/main/java/com/blackduck/integration/sca/upload/client/uploaders/ScassUploader.java
@@ -121,7 +121,7 @@ public class ScassUploader {
         String uploadUrl = null;
         try (Response response = initiateResumableUpload(signedUrl, headers)) {
             if (response.getStatusCode() == HttpStatus.SC_CREATED) {
-                uploadUrl = response.getHeaders().get(HttpHeaders.LOCATION); // This is the resumable session URL
+                uploadUrl = getHeaderCaseInsensitive(response.getHeaders(), HttpHeaders.LOCATION); // This is the resumable session URL
             } else {
                 String errorMessage = String.format("Failed to initiate resumable upload. Returned status is %s. Returned status message is %s.",
                     response.getStatusCode(), response.getStatusMessage()
@@ -219,7 +219,7 @@ public class ScassUploader {
                 } else if (response.getStatusCode() == PERMANENT_REDIRECT) {
                     // Chunk was uploaded successfully, GCS waits for next chunk
                     Map<String, String> responseHeaders = response.getHeaders();
-                    String range = responseHeaders.get(HttpHeaders.RANGE);
+                    String range = getHeaderCaseInsensitive(responseHeaders, HttpHeaders.RANGE);
                     if (range != null) {
                         String[] rangeParts = range.split("-");
                         // offset should be taken from response, since that indicates the last byte that was really stored in GCS bucket
@@ -271,6 +271,46 @@ public class ScassUploader {
 
         // safe to cast since remaining bytes are less than chunk size, which is int
         return remainingBytes < chunkSize ? (int) remainingBytes : chunkSize;
+    }
+
+    /**
+     * Performs a case-insensitive lookup of a header value in a map.
+     * HTTP headers are case-insensitive per RFC 2616, but HashMap is case-sensitive.
+     * Tries exact match first for performance, then common variations, then full scan.
+     *
+     * @param headers the map of headers to search
+     * @param headerName the name of the header to find
+     * @return the header value if found, null otherwise
+     */
+    private String getHeaderCaseInsensitive(Map<String, String> headers, String headerName) {
+        if (headers == null || headerName == null) {
+            return null;
+        }
+
+        // Fast path: try exact match first
+        String value = headers.get(headerName);
+        if (value != null) {
+            return value;
+        }
+
+        // Try common variations before full scan
+        value = headers.get(headerName.toLowerCase());
+        if (value != null) {
+            return value;
+        }
+
+        value = headers.get(headerName.toUpperCase());
+        if (value != null) {
+            return value;
+        }
+
+        // Fall back to case-insensitive search only if needed
+        for (Map.Entry<String, String> entry : headers.entrySet()) {
+            if (entry.getKey().equalsIgnoreCase(headerName)) {
+                return entry.getValue();
+            }
+        }
+        return null;
     }
 
 }

--- a/src/main/java/com/blackduck/integration/sca/upload/client/uploaders/ScassUploader.java
+++ b/src/main/java/com/blackduck/integration/sca/upload/client/uploaders/ScassUploader.java
@@ -32,6 +32,7 @@ import com.blackduck.integration.rest.client.IntHttpClient;
 import com.blackduck.integration.rest.request.Request;
 import com.blackduck.integration.rest.response.Response;
 import com.blackduck.integration.sca.upload.rest.status.ScassUploadStatus;
+import com.blackduck.integration.sca.upload.util.HttpHeaderUtils;
 import com.blackduck.integration.sca.upload.validation.UploadValidator;
 
 /**
@@ -121,7 +122,7 @@ public class ScassUploader {
         String uploadUrl = null;
         try (Response response = initiateResumableUpload(signedUrl, headers)) {
             if (response.getStatusCode() == HttpStatus.SC_CREATED) {
-                uploadUrl = getHeaderCaseInsensitive(response.getHeaders(), HttpHeaders.LOCATION); // This is the resumable session URL
+                uploadUrl = HttpHeaderUtils.getHeaderCaseInsensitive(response.getHeaders(), HttpHeaders.LOCATION); // This is the resumable session URL
             } else {
                 String errorMessage = String.format("Failed to initiate resumable upload. Returned status is %s. Returned status message is %s.",
                     response.getStatusCode(), response.getStatusMessage()
@@ -219,7 +220,7 @@ public class ScassUploader {
                 } else if (response.getStatusCode() == PERMANENT_REDIRECT) {
                     // Chunk was uploaded successfully, GCS waits for next chunk
                     Map<String, String> responseHeaders = response.getHeaders();
-                    String range = getHeaderCaseInsensitive(responseHeaders, HttpHeaders.RANGE);
+                    String range = HttpHeaderUtils.getHeaderCaseInsensitive(responseHeaders, HttpHeaders.RANGE);
                     if (range != null) {
                         String[] rangeParts = range.split("-");
                         // offset should be taken from response, since that indicates the last byte that was really stored in GCS bucket
@@ -271,46 +272,6 @@ public class ScassUploader {
 
         // safe to cast since remaining bytes are less than chunk size, which is int
         return remainingBytes < chunkSize ? (int) remainingBytes : chunkSize;
-    }
-
-    /**
-     * Performs a case-insensitive lookup of a header value in a map.
-     * HTTP headers are case-insensitive per RFC 2616, but HashMap is case-sensitive.
-     * Tries exact match first for performance, then common variations, then full scan.
-     *
-     * @param headers the map of headers to search
-     * @param headerName the name of the header to find
-     * @return the header value if found, null otherwise
-     */
-    private String getHeaderCaseInsensitive(Map<String, String> headers, String headerName) {
-        if (headers == null || headerName == null) {
-            return null;
-        }
-
-        // Fast path: try exact match first
-        String value = headers.get(headerName);
-        if (value != null) {
-            return value;
-        }
-
-        // Try common variations before full scan
-        value = headers.get(headerName.toLowerCase());
-        if (value != null) {
-            return value;
-        }
-
-        value = headers.get(headerName.toUpperCase());
-        if (value != null) {
-            return value;
-        }
-
-        // Fall back to case-insensitive search only if needed
-        for (Map.Entry<String, String> entry : headers.entrySet()) {
-            if (entry.getKey().equalsIgnoreCase(headerName)) {
-                return entry.getValue();
-            }
-        }
-        return null;
     }
 
 }

--- a/src/main/java/com/blackduck/integration/sca/upload/file/FileUploader.java
+++ b/src/main/java/com/blackduck/integration/sca/upload/file/FileUploader.java
@@ -12,7 +12,6 @@ import java.io.RandomAccessFile;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -44,6 +43,7 @@ import com.blackduck.integration.sca.upload.rest.model.ContentTypes;
 import com.blackduck.integration.sca.upload.rest.model.request.MultipartUploadStartRequest;
 import com.blackduck.integration.sca.upload.rest.status.MutableResponseStatus;
 import com.blackduck.integration.sca.upload.rest.status.UploadStatus;
+import com.blackduck.integration.sca.upload.util.HttpHeaderUtils;
 import com.blackduck.integration.sca.upload.validation.UploadValidator;
 import com.google.gson.Gson;
 
@@ -191,12 +191,9 @@ public class FileUploader {
             // Handle errors
             httpClient.throwExceptionForError(response);
 
-
             Map<String, String> responseHeaders = response.getHeaders();
-            Map<String, String> caseInsensitiveResponseHeaders = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
-            caseInsensitiveResponseHeaders.putAll(responseHeaders);
-
-            return Optional.ofNullable(caseInsensitiveResponseHeaders.get(HttpHeaders.LOCATION)).orElseThrow(() -> new IntegrationException("Could not find Location header."));
+            return Optional.ofNullable(HttpHeaderUtils.getHeaderCaseInsensitive(responseHeaders, HttpHeaders.LOCATION))
+                .orElseThrow(() -> new IntegrationException("Could not find Location header."));
         } catch (IOException ex) {
             throw new IntegrationException(CLOSE_RESPONSE_OBJECT_MESSAGE + ex.getCause(), ex);
         }

--- a/src/main/java/com/blackduck/integration/sca/upload/util/HttpHeaderUtils.java
+++ b/src/main/java/com/blackduck/integration/sca/upload/util/HttpHeaderUtils.java
@@ -15,10 +15,6 @@ import java.util.Map;
  */
 public class HttpHeaderUtils {
 
-    private HttpHeaderUtils() {
-        // Utility class, prevent instantiation
-    }
-
     /**
      * Performs a case-insensitive lookup of a header value in a map.
      * HTTP headers are case-insensitive per RFC 2616, but HashMap is case-sensitive.

--- a/src/main/java/com/blackduck/integration/sca/upload/util/HttpHeaderUtils.java
+++ b/src/main/java/com/blackduck/integration/sca/upload/util/HttpHeaderUtils.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-upload-common
  *
- * Copyright (c) 2025 Black Duck Software, Inc.
+ * Copyright (c) 2026 Black Duck Software, Inc.
  *
  * Use subject to the terms and conditions of the Black Duck Software End User Software License and Maintenance
  * Agreement. All rights reserved worldwide.

--- a/src/main/java/com/blackduck/integration/sca/upload/util/HttpHeaderUtils.java
+++ b/src/main/java/com/blackduck/integration/sca/upload/util/HttpHeaderUtils.java
@@ -1,0 +1,61 @@
+/*
+ * blackduck-upload-common
+ *
+ * Copyright (c) 2025 Black Duck Software, Inc.
+ *
+ * Use subject to the terms and conditions of the Black Duck Software End User Software License and Maintenance
+ * Agreement. All rights reserved worldwide.
+ */
+package com.blackduck.integration.sca.upload.util;
+
+import java.util.Map;
+
+/**
+ * Utility class for HTTP header operations.
+ */
+public class HttpHeaderUtils {
+
+    private HttpHeaderUtils() {
+        // Utility class, prevent instantiation
+    }
+
+    /**
+     * Performs a case-insensitive lookup of a header value in a map.
+     * HTTP headers are case-insensitive per RFC 2616, but HashMap is case-sensitive.
+     * Tries exact match first for performance, then common variations, then full scan.
+     *
+     * @param headers the map of headers to search
+     * @param headerName the name of the header to find
+     * @return the header value if found, null otherwise
+     */
+    public static String getHeaderCaseInsensitive(Map<String, String> headers, String headerName) {
+        if (headers == null || headerName == null) {
+            return null;
+        }
+
+        // Fast path: try exact match first
+        String value = headers.get(headerName);
+        if (value != null) {
+            return value;
+        }
+
+        // Try common variations before full scan
+        value = headers.get(headerName.toLowerCase());
+        if (value != null) {
+            return value;
+        }
+
+        value = headers.get(headerName.toUpperCase());
+        if (value != null) {
+            return value;
+        }
+
+        // Fall back to case-insensitive search only if needed
+        for (Map.Entry<String, String> entry : headers.entrySet()) {
+            if (entry.getKey().equalsIgnoreCase(headerName)) {
+                return entry.getValue();
+            }
+        }
+        return null;
+    }
+}

--- a/src/test/java/com/blackduck/integration/sca/upload/client/uploaders/ScassUploaderTest.java
+++ b/src/test/java/com/blackduck/integration/sca/upload/client/uploaders/ScassUploaderTest.java
@@ -233,4 +233,76 @@ public class ScassUploaderTest {
         Mockito.when(response.getContentString()).thenReturn(content);
     }
 
+    @Test
+    public void testLocationHeaderLowercase() throws Exception {
+        Response initialResponse = Mockito.mock(Response.class);
+        Mockito.when(initialResponse.getStatusCode()).thenReturn(HttpStatus.SC_CREATED);
+        Mockito.when(initialResponse.getHeaders()).thenReturn(Map.of("location", "https://example.com/upload/resumable"));
+
+        Response chunkResponse = Mockito.mock(Response.class);
+        Mockito.when(chunkResponse.getStatusCode()).thenReturn(HttpStatus.SC_OK);
+
+        Mockito.when(client.execute(any(Request.class))).thenReturn(initialResponse, chunkResponse);
+
+        ScassUploadStatus status = scassUploader.upload(HttpMethod.POST, SIGNED_URL, HEADERS, UPLOADED_FILE_PATH);
+
+        assertEquals(HttpStatus.SC_OK, status.getStatusCode());
+    }
+
+    @Test
+    public void testLocationHeaderUppercase() throws Exception {
+        Response initialResponse = Mockito.mock(Response.class);
+        Mockito.when(initialResponse.getStatusCode()).thenReturn(HttpStatus.SC_CREATED);
+        Mockito.when(initialResponse.getHeaders()).thenReturn(Map.of("Location", "https://example.com/upload/resumable"));
+
+        Response chunkResponse = Mockito.mock(Response.class);
+        Mockito.when(chunkResponse.getStatusCode()).thenReturn(HttpStatus.SC_OK);
+
+        Mockito.when(client.execute(any(Request.class))).thenReturn(initialResponse, chunkResponse);
+
+        ScassUploadStatus status = scassUploader.upload(HttpMethod.POST, SIGNED_URL, HEADERS, UPLOADED_FILE_PATH);
+
+        assertEquals(HttpStatus.SC_OK, status.getStatusCode());
+    }
+
+    @Test
+    public void testRangeHeaderLowercase() throws Exception {
+        Response initialResponse = Mockito.mock(Response.class);
+        Mockito.when(initialResponse.getStatusCode()).thenReturn(HttpStatus.SC_CREATED);
+        Mockito.when(initialResponse.getHeaders()).thenReturn(Map.of(HttpHeaders.LOCATION, "https://example.com/upload/resumable"));
+
+        Response chunkResponse = Mockito.mock(Response.class);
+        Mockito.when(chunkResponse.getStatusCode()).thenReturn(ScassUploader.PERMANENT_REDIRECT);
+        Mockito.when(chunkResponse.getHeaders()).thenReturn(Map.of("range", "bytes=0-100"));
+
+        Response finalResponse = Mockito.mock(Response.class);
+        Mockito.when(finalResponse.getStatusCode()).thenReturn(HttpStatus.SC_OK);
+
+        Mockito.when(client.execute(any(Request.class))).thenReturn(initialResponse, chunkResponse, finalResponse);
+
+        ScassUploadStatus status = scassUploader.upload(HttpMethod.POST, SIGNED_URL, HEADERS, UPLOADED_FILE_PATH);
+
+        assertEquals(HttpStatus.SC_OK, status.getStatusCode());
+    }
+
+    @Test
+    public void testRangeHeaderUppercase() throws Exception {
+        Response initialResponse = Mockito.mock(Response.class);
+        Mockito.when(initialResponse.getStatusCode()).thenReturn(HttpStatus.SC_CREATED);
+        Mockito.when(initialResponse.getHeaders()).thenReturn(Map.of(HttpHeaders.LOCATION, "https://example.com/upload/resumable"));
+
+        Response chunkResponse = Mockito.mock(Response.class);
+        Mockito.when(chunkResponse.getStatusCode()).thenReturn(ScassUploader.PERMANENT_REDIRECT);
+        Mockito.when(chunkResponse.getHeaders()).thenReturn(Map.of("Range", "bytes=0-100"));
+
+        Response finalResponse = Mockito.mock(Response.class);
+        Mockito.when(finalResponse.getStatusCode()).thenReturn(HttpStatus.SC_OK);
+
+        Mockito.when(client.execute(any(Request.class))).thenReturn(initialResponse, chunkResponse, finalResponse);
+
+        ScassUploadStatus status = scassUploader.upload(HttpMethod.POST, SIGNED_URL, HEADERS, UPLOADED_FILE_PATH);
+
+        assertEquals(HttpStatus.SC_OK, status.getStatusCode());
+    }
+
 }


### PR DESCRIPTION
This changes the SCASSUploader to do case insensitive lookups on its headers. The problem is that we sometimes get things like "location" instead of "Location" and the current code breaks.

To get around this I've introduced a way to look for the header names in a case insensitive fashion. 

Note: This is being done internal to ScassUploader as we are trying to reduce the scope of the change. It might be possible to address this in other ways but those likely would mean changing other libraries, like integration-rest, but we were specifically asked not to spread impact in that direction.