### PR TITLE
Stop ScassUploader loop

### DIFF
--- a/src/main/java/com/blackduck/integration/sca/upload/client/uploaders/ScassUploader.java
+++ b/src/main/java/com/blackduck/integration/sca/upload/client/uploaders/ScassUploader.java
@@ -149,7 +149,7 @@ public class ScassUploader {
                 chunkHeaders.put(HttpHeaders.CONTENT_RANGE, rangeValue);
 
                 ScassUploadStatus status = uploadChunk(uploadUrl, chunkHeaders, chunk, offset);
-                if (status.getStatusCode() != HttpStatus.SC_OK && status.getStatusCode() != PERMANENT_REDIRECT) {
+                if (status.isError() || (status.getStatusCode() != HttpStatus.SC_OK && status.getStatusCode() != PERMANENT_REDIRECT)) {
                     // this is error status, so break the cycle and return it
                     return status;
                 }

--- a/src/test/java/com/blackduck/integration/sca/upload/client/uploaders/ScassUploaderTest.java
+++ b/src/test/java/com/blackduck/integration/sca/upload/client/uploaders/ScassUploaderTest.java
@@ -227,6 +227,38 @@ public class ScassUploaderTest {
         Mockito.verify(chunkResponse3, times(1)).close();
     }
 
+    @Test
+    // Test that a 308 response missing the Range header causes an error rather than an infinite loop.
+    // When uploadChunk() gets a 308 but cannot find the Range header it throws, and the catch block
+    // returns the 308 status code alongside the exception. resumableUpload() must detect isError()
+    // so it does not treat the 308 as a successful intermediate chunk and loop forever from offset 0.
+    public void testWhenPostUploadChunkReturns308WithoutRangeHeader() throws Exception {
+        Response initialResponse = Mockito.mock(Response.class);
+        Mockito.when(initialResponse.getStatusCode()).thenReturn(HttpStatus.SC_CREATED);
+        Mockito.when(initialResponse.getHeaders()).thenReturn(Map.of(HttpHeaders.LOCATION, "https://example.com/upload/resumable"));
+
+        // 308 response with no Range header — simulates the bug scenario
+        Response chunkResponse = Mockito.mock(Response.class);
+        Mockito.when(chunkResponse.getStatusCode()).thenReturn(ScassUploader.PERMANENT_REDIRECT);
+        Mockito.when(chunkResponse.getHeaders()).thenReturn(new HashMap<>());
+        Mockito.when(chunkResponse.getStatusMessage()).thenReturn("Permanent Redirect");
+        Mockito.when(chunkResponse.getContentString()).thenReturn(ERROR_CONTENT);
+
+        // initial + (MULTIPART_UPLOAD_PART_RETRY_ATTEMPTS + 1) chunk attempts
+        Mockito.when(client.execute(any(Request.class))).thenReturn(
+            initialResponse,
+            chunkResponse, chunkResponse, chunkResponse
+        );
+
+        ScassUploadStatus status = scassUploader.upload(HttpMethod.POST, SIGNED_URL, HEADERS, UPLOADED_FILE_PATH);
+
+        assertEquals(ScassUploader.PERMANENT_REDIRECT, status.getStatusCode());
+        assertEquals(true, status.isError());
+
+        // Verify we only executed the expected number of requests and did not loop infinitely
+        Mockito.verify(client, times(1 + MULTIPART_UPLOAD_PART_RETRY_ATTEMPTS + 1)).execute(any(Request.class));
+    }
+
     private void mockResponse(Response response, int status, String statusMessage, String content) throws IntegrationException {
         Mockito.when(response.getStatusCode()).thenReturn(status);
         Mockito.when(response.getStatusMessage()).thenReturn(statusMessage);

--- a/src/test/java/com/blackduck/integration/sca/upload/client/uploaders/ScassUploaderTest.java
+++ b/src/test/java/com/blackduck/integration/sca/upload/client/uploaders/ScassUploaderTest.java
@@ -228,23 +228,23 @@ public class ScassUploaderTest {
     }
 
     @Test
-    // Test that a 308 response missing the Range header causes an error rather than an infinite loop.
-    // When uploadChunk() gets a 308 but cannot find the Range header it throws, and the catch block
-    // returns the 308 status code alongside the exception. resumableUpload() must detect isError()
-    // so it does not treat the 308 as a successful intermediate chunk and loop forever from offset 0.
+	// Test that a 308 response missing the Range header causes an error rather than
+	// an infinite loop. When uploadChunk() gets a 308 but cannot find the Range
+	// header it throws an exception, and the catch block returns the 308 status
+	// code alongside the exception. resumableUpload() must detect isError() so it
+	// does not treat the 308 as a successful intermediate chunk and loop forever from offset 0.
     public void testWhenPostUploadChunkReturns308WithoutRangeHeader() throws Exception {
         Response initialResponse = Mockito.mock(Response.class);
         Mockito.when(initialResponse.getStatusCode()).thenReturn(HttpStatus.SC_CREATED);
         Mockito.when(initialResponse.getHeaders()).thenReturn(Map.of(HttpHeaders.LOCATION, "https://example.com/upload/resumable"));
 
-        // 308 response with no Range header — simulates the bug scenario
+        // 308 response with no Range header
         Response chunkResponse = Mockito.mock(Response.class);
         Mockito.when(chunkResponse.getStatusCode()).thenReturn(ScassUploader.PERMANENT_REDIRECT);
         Mockito.when(chunkResponse.getHeaders()).thenReturn(new HashMap<>());
         Mockito.when(chunkResponse.getStatusMessage()).thenReturn("Permanent Redirect");
         Mockito.when(chunkResponse.getContentString()).thenReturn(ERROR_CONTENT);
 
-        // initial + (MULTIPART_UPLOAD_PART_RETRY_ATTEMPTS + 1) chunk attempts
         Mockito.when(client.execute(any(Request.class))).thenReturn(
             initialResponse,
             chunkResponse, chunkResponse, chunkResponse


### PR DESCRIPTION
When uploadChunk() fails because it can't find the Range header it returns the response, which happens to have a successful (308) code. So resumableUpload() seeks to the new offset of 0 and does it all again.

This will never work because there actually was an error that we are not checking. The class has an isError method to check if the call was successful and we should be using this, likely in addition, to the status code.